### PR TITLE
Corrigir erro de workspace no Angular

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -53,7 +53,6 @@
       }
     }
   },
-  "defaultProject": "frontend",
   "cli": {
     "analytics": "cfe2b453-b67b-4e1f-a9d2-c9563d52aba1"
   }


### PR DESCRIPTION
## Resumo
- remover `defaultProject` de `angular.json` para evitar erro de extensão inválida

## Testes
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6895481999348328b6efa97f0bba06cc