### PR TITLE
Fix dev-server build target configuration

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -42,11 +42,11 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "frontend:build"  // Certifique-se de que esta linha está correta
+            "buildTarget": "frontend:build"
           },
           "configurations": {
             "production": {
-              "browserTarget": "frontend:build:production"
+              "buildTarget": "frontend:build:production"
             }
           }
         }


### PR DESCRIPTION
## Summary
- update the Angular dev-server configuration to use buildTarget instead of browserTarget
- remove invalid comment inside angular.json

## Testing
- npm test (frontend)
- npm test (backend)

------
https://chatgpt.com/codex/tasks/task_e_68ce0f10b8648328b96e0c5bcd6bf41d