### PR TITLE
Corrige exibição da tela de login no frontend

### DIFF
--- a/frontend/src/app/modules/login/login.component.html
+++ b/frontend/src/app/modules/login/login.component.html
@@ -203,7 +203,7 @@
 
       <div class="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-2xl">
         <p class="text-sm text-blue-700">
-          <strong>Para testar:</strong> admin@plataforma.gov / 123456
+          <strong>Para testar:</strong> admin&#64;plataforma.gov / 123456
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Sumário
- Escapa o caractere `@` no template do login para evitar erro de compilação com os novos blocos de controle do Angular

## Testes
- npm test (frontend)
- npm test (backend)

------
https://chatgpt.com/codex/tasks/task_e_68ce189452148328988e30ae44c1724c