### PR TITLE
Garante carregamento do Zone.js no bootstrap do frontend

### DIFF
--- a/frontend/src/app/modules/login/login.component.html
+++ b/frontend/src/app/modules/login/login.component.html
@@ -203,7 +203,7 @@
 
       <div class="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-2xl">
         <p class="text-sm text-blue-700">
-          <strong>Para testar:</strong> admin@plataforma.gov / 123456
+          <strong>Para testar:</strong> admin&#64;plataforma.gov / 123456
         </p>
       </div>
     </div>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,4 @@
+import 'zone.js';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 


### PR DESCRIPTION
## Sumário
- Importa `zone.js` antes do bootstrap do `AppModule` para evitar o erro NG0908 e permitir que a tela de login seja renderizada

## Testes
- npm test (frontend)
- npm test (backend)

------
https://chatgpt.com/codex/tasks/task_e_68ce189452148328988e30ae44c1724c