### PR TITLE
Adicionar menu superior pós-login

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
   { path: 'login', loadChildren: () => import('./modules/login/login.module').then(m => m.LoginModule) },
   { path: 'dashboard', loadChildren: () => import('./modules/dashboard/dashboard.module').then(m => m.DashboardModule) },
+  { path: 'familias', loadChildren: () => import('./modules/familias/familias.module').then(m => m.FamiliasModule) },
   { path: '**', redirectTo: 'login' }
 ];
 

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,1 +1,4 @@
-<router-outlet></router-outlet>
+<div class="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50">
+  <app-top-nav *ngIf="showTopNav"></app-top-nav>
+  <router-outlet></router-outlet>
+</div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,8 +1,20 @@
 import { Component } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs';
 
 @Component({
-  standalone: false,
   selector: 'app-root',
   templateUrl: './app.component.html'
 })
-export class AppComponent {}
+export class AppComponent {
+  showTopNav = false;
+
+  constructor(private router: Router) {
+    this.showTopNav = !this.router.url.startsWith('/login');
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe((event: NavigationEnd) => {
+        this.showTopNav = !event.urlAfterRedirects.startsWith('/login');
+      });
+  }
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -3,9 +3,10 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { TopNavComponent } from './components/top-nav/top-nav.component';
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [AppComponent, TopNavComponent],
   imports: [BrowserModule, HttpClientModule, AppRoutingModule],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/components/top-nav/top-nav.component.css
+++ b/frontend/src/app/components/top-nav/top-nav.component.css
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.active-nav {
+  color: #1d4ed8;
+  background-color: #eff6ff;
+}
+
+.active-nav span:last-child {
+  opacity: 1;
+}

--- a/frontend/src/app/components/top-nav/top-nav.component.html
+++ b/frontend/src/app/components/top-nav/top-nav.component.html
@@ -1,0 +1,57 @@
+<nav class="bg-white/90 backdrop-blur border-b border-gray-200 shadow-sm">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="flex h-16 items-center justify-between">
+      <div class="flex items-center space-x-3">
+        <div class="w-10 h-10 gradient-blue rounded-xl flex items-center justify-center shadow-lg">
+          <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c1.657 0 3-1.79 3-4s-1.343-4-3-4-3 1.79-3 4 1.343 4 3 4z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 22v-2a6 6 0 016-6h4a6 6 0 016 6v2" />
+          </svg>
+        </div>
+        <div>
+          <div class="text-base font-bold text-gray-900">Gestor Político</div>
+          <div class="text-xs text-gray-500">Plataforma de gestão estratégica</div>
+        </div>
+      </div>
+
+      <div class="hidden md:flex items-center space-x-1">
+        <a
+          *ngFor="let item of menuItems"
+          [routerLink]="item.route"
+          routerLinkActive="active-nav"
+          [routerLinkActiveOptions]="{ exact: item.route === '/dashboard' }"
+          class="relative px-4 py-2 rounded-xl text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 transition-colors flex items-center space-x-2"
+        >
+          <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-50 text-blue-500">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <path [attr.d]="item.icon" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </span>
+          <span>
+            <span class="block">{{ item.label }}</span>
+            <span class="block text-[11px] text-gray-400">{{ item.description }}</span>
+          </span>
+          <span class="absolute inset-x-4 -bottom-1 h-1 rounded-full bg-gradient-to-r from-blue-400 to-blue-600 opacity-0 transition-opacity" aria-hidden="true"></span>
+        </a>
+      </div>
+
+      <div class="flex items-center space-x-4">
+        <button class="relative p-2 text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded-xl transition-colors">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-5 5v-5zM9 17H4l5 5v-5z" />
+          </svg>
+          <span class="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full"></span>
+        </button>
+        <div class="flex items-center space-x-3">
+          <div class="text-right">
+            <div class="text-sm font-semibold text-gray-900">Ana Martins</div>
+            <div class="text-xs text-gray-500">Coordenadora de Campanha</div>
+          </div>
+          <div class="w-10 h-10 rounded-2xl gradient-blue flex items-center justify-center text-white font-semibold">
+            AM
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/frontend/src/app/components/top-nav/top-nav.component.ts
+++ b/frontend/src/app/components/top-nav/top-nav.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+
+interface TopNavItem {
+  label: string;
+  description: string;
+  icon: string;
+  route: string;
+}
+
+@Component({
+  selector: 'app-top-nav',
+  templateUrl: './top-nav.component.html',
+  styleUrls: ['./top-nav.component.css']
+})
+export class TopNavComponent {
+  menuItems: TopNavItem[] = [
+    {
+      label: 'Dashboard',
+      description: 'Visão geral dos indicadores',
+      icon: 'M3 13.5h4.5V21H3v-7.5zm6-9H13.5V21H9V4.5zm6 6H21V21h-6V10.5z',
+      route: '/dashboard'
+    },
+    {
+      label: 'Famílias',
+      description: 'Gestão de núcleos familiares',
+      icon: 'M12 7a4 4 0 110 8 4 4 0 010-8zm0-5a6 6 0 016 6v1.26a8 8 0 014 6.91V21h-2v-4a4 4 0 00-4-4h-8a4 4 0 00-4 4v4H2v-4.83a8 8 0 014-6.91V8a6 6 0 016-6z',
+      route: '/familias'
+    },
+    {
+      label: 'Indicadores',
+      description: 'Relatórios e projeções',
+      icon: 'M4 6h16M4 12h10M4 18h6',
+      route: '/dashboard'
+    }
+  ];
+}

--- a/frontend/src/app/modules/familias/familias.component.css
+++ b/frontend/src/app/modules/familias/familias.component.css
@@ -1,0 +1,7 @@
+:host {
+  display: block;
+}
+
+.shadow-inner {
+  box-shadow: inset 0 1px 4px rgba(37, 99, 235, 0.15);
+}

--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -1,0 +1,207 @@
+<div class="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50 pb-12">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6 mb-10">
+      <div>
+        <div class="inline-flex items-center px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold mb-3">
+          Gestão de famílias
+        </div>
+        <h1 class="text-3xl font-bold text-gray-900 mb-2">Famílias e núcleos sociais</h1>
+        <p class="text-gray-600 max-w-2xl">
+          Acompanhe os núcleos familiares cadastrados, identifique responsáveis estratégicos e mantenha o relacionamento ativo com as lideranças comunitárias.
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <button class="px-5 py-3 rounded-2xl border border-gray-200 text-gray-600 text-sm font-medium hover:bg-white transition-all">
+          Importar planilha
+        </button>
+        <button class="px-5 py-3 rounded-2xl gradient-blue text-white text-sm font-semibold shadow-lg hover:opacity-90 transition-all">
+          + Nova família
+        </button>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+      <div
+        *ngFor="let destaque of destaques"
+        class="bg-white rounded-3xl p-6 shadow-lg border border-gray-100 hover:shadow-xl transition-all duration-300"
+      >
+        <div class="text-sm font-semibold text-blue-500 mb-3">{{ destaque.variacao }}</div>
+        <div class="text-3xl font-bold text-gray-900 mb-2">{{ destaque.valor }}</div>
+        <div class="text-sm text-gray-500">{{ destaque.titulo }}</div>
+        <div class="mt-4 text-xs text-gray-400">{{ destaque.descricao }}</div>
+      </div>
+    </div>
+
+    <div class="bg-white rounded-3xl shadow-lg border border-gray-100 overflow-hidden">
+      <div class="px-6 py-4 border-b border-gray-100 flex flex-wrap items-center justify-between gap-4">
+        <div class="flex items-center space-x-3">
+          <div class="w-10 h-10 gradient-blue rounded-2xl flex items-center justify-center text-white">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 7a4 4 0 110 8 4 4 0 010-8zm0-5a6 6 0 016 6v1.26a8 8 0 014 6.91V21h-2v-4a4 4 0 00-4-4h-8a4 4 0 00-4 4v4H2v-4.83a8 8 0 014-6.91V8a6 6 0 016-6z" />
+            </svg>
+          </div>
+          <div>
+            <div class="text-lg font-semibold text-gray-900">Rede familiar cadastrada</div>
+            <div class="text-sm text-gray-500">Listagem com filtros inteligentes</div>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            *ngFor="let filtro of filtros; let i = index"
+            class="px-4 py-2 rounded-full text-sm font-medium transition-all"
+            [ngClass]="{
+              'bg-blue-50 text-blue-600 shadow-inner': i === 0,
+              'bg-gray-50 text-gray-500 hover:bg-blue-50 hover:text-blue-600': i !== 0
+            }"
+          >
+            {{ filtro }}
+          </button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6 bg-gray-50">
+        <div class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all">
+          <div class="flex items-start justify-between">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900 mb-1">Família Sousa Lima</h2>
+              <p class="text-sm text-gray-500">Jardim Aurora • Zona Norte</p>
+            </div>
+            <span class="px-3 py-1 rounded-full bg-emerald-50 text-emerald-600 text-xs font-semibold">Alta influência</span>
+          </div>
+          <div class="mt-4 grid grid-cols-3 gap-4 text-center">
+            <div>
+              <div class="text-2xl font-bold text-gray-900">06</div>
+              <div class="text-xs text-gray-500">Membros</div>
+            </div>
+            <div>
+              <div class="text-2xl font-bold text-gray-900">02</div>
+              <div class="text-xs text-gray-500">Projetos ativos</div>
+            </div>
+            <div>
+              <div class="text-2xl font-bold text-gray-900">89%</div>
+              <div class="text-xs text-gray-500">Engajamento</div>
+            </div>
+          </div>
+          <div class="mt-5 flex items-center justify-between">
+            <div class="flex -space-x-2">
+              <div class="w-8 h-8 rounded-full bg-blue-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-blue-600">
+                MS
+              </div>
+              <div class="w-8 h-8 rounded-full bg-purple-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-purple-600">
+                LS
+              </div>
+              <div class="w-8 h-8 rounded-full bg-emerald-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-emerald-600">
+                +4
+              </div>
+            </div>
+            <div class="flex items-center space-x-2 text-sm text-blue-600 font-medium">
+              <span>Ver detalhes</span>
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all">
+          <div class="flex items-start justify-between">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900 mb-1">Família Albuquerque</h2>
+              <p class="text-sm text-gray-500">Vila Esperança • Zona Leste</p>
+            </div>
+            <span class="px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold">Média influência</span>
+          </div>
+          <div class="mt-4 grid grid-cols-3 gap-4 text-center">
+            <div>
+              <div class="text-2xl font-bold text-gray-900">04</div>
+              <div class="text-xs text-gray-500">Membros</div>
+            </div>
+            <div>
+              <div class="text-2xl font-bold text-gray-900">01</div>
+              <div class="text-xs text-gray-500">Projetos ativos</div>
+            </div>
+            <div>
+              <div class="text-2xl font-bold text-gray-900">72%</div>
+              <div class="text-xs text-gray-500">Engajamento</div>
+            </div>
+          </div>
+          <div class="mt-5 flex items-center justify-between">
+            <div class="flex -space-x-2">
+              <div class="w-8 h-8 rounded-full bg-blue-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-blue-600">
+                PA
+              </div>
+              <div class="w-8 h-8 rounded-full bg-pink-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-pink-600">
+                TA
+              </div>
+              <div class="w-8 h-8 rounded-full bg-gray-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-gray-500">
+                +2
+              </div>
+            </div>
+            <div class="flex items-center space-x-2 text-sm text-blue-600 font-medium">
+              <span>Ver detalhes</span>
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all lg:col-span-2">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900 mb-1">Próximas ações recomendadas</h2>
+              <p class="text-sm text-gray-500">Sugestões baseadas nos níveis de engajamento</p>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="flex items-center px-3 py-1 rounded-full bg-emerald-50 text-emerald-600 text-xs font-semibold">
+                <span class="w-2 h-2 rounded-full bg-emerald-500 mr-2"></span>
+                Prioridade alta
+              </span>
+              <span class="flex items-center px-3 py-1 rounded-full bg-amber-50 text-amber-600 text-xs font-semibold">
+                <span class="w-2 h-2 rounded-full bg-amber-500 mr-2"></span>
+                Prioridade média
+              </span>
+            </div>
+          </div>
+          <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="p-4 rounded-2xl border border-gray-100 hover:border-blue-200 transition-all">
+              <div class="flex items-center justify-between mb-3">
+                <div class="flex items-center space-x-3">
+                  <div class="w-10 h-10 rounded-2xl bg-blue-50 text-blue-600 flex items-center justify-center">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.59 14.37L18 16.78 19.41 15.37 17 12.95M11 5H6a2 2 0 00-2 2v13l4-2 4 2V7a2 2 0 00-2-2h1" />
+                    </svg>
+                  </div>
+                  <div>
+                    <div class="text-sm font-semibold text-gray-900">Reunião com responsáveis</div>
+                    <div class="text-xs text-gray-500">Família Sousa Lima • até 18/04</div>
+                  </div>
+                </div>
+                <span class="px-2 py-1 rounded-full bg-emerald-100 text-emerald-600 text-[11px] font-semibold">Alta</span>
+              </div>
+              <p class="text-sm text-gray-500">Confirmar presença em evento comunitário e alinhar demandas locais prioritárias.</p>
+            </div>
+
+            <div class="p-4 rounded-2xl border border-gray-100 hover:border-blue-200 transition-all">
+              <div class="flex items-center justify-between mb-3">
+                <div class="flex items-center space-x-3">
+                  <div class="w-10 h-10 rounded-2xl bg-blue-50 text-blue-600 flex items-center justify-center">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m6 4h6M9 21l-6-6h12l-6 6z" />
+                    </svg>
+                  </div>
+                  <div>
+                    <div class="text-sm font-semibold text-gray-900">Mapeamento de novos líderes</div>
+                    <div class="text-xs text-gray-500">Região Leste • até 22/04</div>
+                  </div>
+                </div>
+                <span class="px-2 py-1 rounded-full bg-amber-100 text-amber-600 text-[11px] font-semibold">Média</span>
+              </div>
+              <p class="text-sm text-gray-500">Identificar famílias emergentes com potencial de mobilização para próximas agendas.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-familias',
+  templateUrl: './familias.component.html',
+  styleUrls: ['./familias.component.css']
+})
+export class FamiliasComponent {
+  destaques = [
+    {
+      titulo: 'Famílias cadastradas',
+      valor: '128',
+      variacao: '+8,4%',
+      descricao: 'crescimento nos últimos 30 dias'
+    },
+    {
+      titulo: 'Responsáveis ativos',
+      valor: '94',
+      variacao: '+5,1%',
+      descricao: 'com engajamento confirmado'
+    },
+    {
+      titulo: 'Novos cadastros',
+      valor: '12',
+      variacao: '+3 nesta semana',
+      descricao: 'aguardando validação'
+    }
+  ];
+
+  filtros = ['Todos', 'Zona Norte', 'Zona Sul', 'Zona Leste', 'Zona Oeste'];
+}

--- a/frontend/src/app/modules/familias/familias.module.ts
+++ b/frontend/src/app/modules/familias/familias.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { FamiliasComponent } from './familias.component';
+
+const routes: Routes = [{ path: '', component: FamiliasComponent }];
+
+@NgModule({
+  declarations: [FamiliasComponent],
+  imports: [CommonModule, RouterModule.forChild(routes)]
+})
+export class FamiliasModule {}


### PR DESCRIPTION
## Resumo
- criar componente de navegação superior com identidade visual do dashboard
- habilitar exibição da barra em rotas pós-login e adicionar módulo dedicado às famílias
- estruturar tela inicial de famílias com cards informativos e filtros alinhados ao design atual

## Testes
- `npm test -- --watch=false` (frontend)
- `npm test -- --watch=false` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_68ce1e0bded083288af1cf57249afc30