### PR TITLE
Ajusta configuração standalone do AppComponent

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs';
 
 @Component({
+  standalone: false,
   selector: 'app-root',
   templateUrl: './app.component.html'
 })


### PR DESCRIPTION
## Summary
- define o AppComponent como não standalone para permitir a declaração no AppModule

## Testing
- npm test (frontend)
- npm test (backend)

------
https://chatgpt.com/codex/tasks/task_e_68ce2040782c8328b4a64e1aed694406