### PR TITLE
Persistência de famílias no banco de dados

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -9,6 +9,28 @@ INSERT INTO login (usuario, senha, nome)
 VALUES ('admin@plataforma.gov', '123456', 'Administrador')
 ON CONFLICT (usuario) DO NOTHING;
 
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'grau_parentesco') THEN
+    CREATE TYPE grau_parentesco AS ENUM (
+      'Pai',
+      'Mãe',
+      'Filho(a)',
+      'Filha',
+      'Filho',
+      'Irmão(ã)',
+      'Primo(a)',
+      'Tio(a)',
+      'Sobrinho(a)',
+      'Cônjuge',
+      'Avô(ó)',
+      'Enteado(a)',
+      'Outro'
+    );
+  END IF;
+END
+$$;
+
 CREATE TABLE IF NOT EXISTS familia (
   id SERIAL PRIMARY KEY,
   endereco VARCHAR(255) NOT NULL,
@@ -23,13 +45,19 @@ CREATE TABLE IF NOT EXISTS membro_familia (
   nome_completo VARCHAR(255) NOT NULL,
   data_nascimento DATE,
   profissao VARCHAR(255),
-  parentesco VARCHAR(120) NOT NULL,
-  papel_na_familia VARCHAR(50) NOT NULL,
+  parentesco grau_parentesco NOT NULL,
   responsavel_principal BOOLEAN DEFAULT FALSE,
   probabilidade_voto VARCHAR(20) NOT NULL,
   telefone VARCHAR(30),
   criado_em TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+ALTER TABLE membro_familia
+DROP COLUMN IF EXISTS papel_na_familia;
+
+ALTER TABLE membro_familia
+ALTER COLUMN parentesco TYPE grau_parentesco
+USING parentesco::grau_parentesco;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_membro_familia_principal
 ON membro_familia (familia_id)

--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -24,7 +24,7 @@
       </div>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10" *ngIf="destaques.length > 0">
       <div
         *ngFor="let destaque of destaques"
         class="bg-white rounded-3xl p-6 shadow-lg border border-gray-100 hover:shadow-xl transition-all duration-300"
@@ -63,145 +63,80 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6 bg-gray-50">
-        <div class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all">
-          <div class="flex items-start justify-between">
-            <div>
-              <h2 class="text-lg font-semibold text-gray-900 mb-1">Família Sousa Lima</h2>
-              <p class="text-sm text-gray-500">Jardim Aurora • Zona Norte</p>
-            </div>
-            <span class="px-3 py-1 rounded-full bg-emerald-50 text-emerald-600 text-xs font-semibold">Alta influência</span>
-          </div>
-          <div class="mt-4 grid grid-cols-3 gap-4 text-center">
-            <div>
-              <div class="text-2xl font-bold text-gray-900">06</div>
-              <div class="text-xs text-gray-500">Membros</div>
-            </div>
-            <div>
-              <div class="text-2xl font-bold text-gray-900">02</div>
-              <div class="text-xs text-gray-500">Projetos ativos</div>
-            </div>
-            <div>
-              <div class="text-2xl font-bold text-gray-900">89%</div>
-              <div class="text-xs text-gray-500">Engajamento</div>
-            </div>
-          </div>
-          <div class="mt-5 flex items-center justify-between">
-            <div class="flex -space-x-2">
-              <div class="w-8 h-8 rounded-full bg-blue-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-blue-600">
-                MS
-              </div>
-              <div class="w-8 h-8 rounded-full bg-purple-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-purple-600">
-                LS
-              </div>
-              <div class="w-8 h-8 rounded-full bg-emerald-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-emerald-600">
-                +4
-              </div>
-            </div>
-            <div class="flex items-center space-x-2 text-sm text-blue-600 font-medium">
-              <span>Ver detalhes</span>
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </div>
-          </div>
+      <div class="p-6 bg-gray-50">
+        <div *ngIf="carregando" class="text-center py-10 text-gray-500">Carregando famílias cadastradas...</div>
+
+        <div *ngIf="erroCarregamento" class="text-center py-10 text-red-500 font-semibold">
+          {{ erroCarregamento }}
         </div>
 
-        <div class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all">
-          <div class="flex items-start justify-between">
-            <div>
-              <h2 class="text-lg font-semibold text-gray-900 mb-1">Família Albuquerque</h2>
-              <p class="text-sm text-gray-500">Vila Esperança • Zona Leste</p>
-            </div>
-            <span class="px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold">Média influência</span>
-          </div>
-          <div class="mt-4 grid grid-cols-3 gap-4 text-center">
-            <div>
-              <div class="text-2xl font-bold text-gray-900">04</div>
-              <div class="text-xs text-gray-500">Membros</div>
-            </div>
-            <div>
-              <div class="text-2xl font-bold text-gray-900">01</div>
-              <div class="text-xs text-gray-500">Projetos ativos</div>
-            </div>
-            <div>
-              <div class="text-2xl font-bold text-gray-900">72%</div>
-              <div class="text-xs text-gray-500">Engajamento</div>
-            </div>
-          </div>
-          <div class="mt-5 flex items-center justify-between">
-            <div class="flex -space-x-2">
-              <div class="w-8 h-8 rounded-full bg-blue-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-blue-600">
-                PA
-              </div>
-              <div class="w-8 h-8 rounded-full bg-pink-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-pink-600">
-                TA
-              </div>
-              <div class="w-8 h-8 rounded-full bg-gray-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-gray-500">
-                +2
-              </div>
-            </div>
-            <div class="flex items-center space-x-2 text-sm text-blue-600 font-medium">
-              <span>Ver detalhes</span>
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </div>
-          </div>
+        <div
+          *ngIf="!carregando && !erroCarregamento && familias.length === 0"
+          class="text-center py-10 text-gray-500"
+        >
+          Nenhuma família cadastrada até o momento.
         </div>
 
-        <div class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all lg:col-span-2">
-          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div>
-              <h2 class="text-lg font-semibold text-gray-900 mb-1">Próximas ações recomendadas</h2>
-              <p class="text-sm text-gray-500">Sugestões baseadas nos níveis de engajamento</p>
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="flex items-center px-3 py-1 rounded-full bg-emerald-50 text-emerald-600 text-xs font-semibold">
-                <span class="w-2 h-2 rounded-full bg-emerald-500 mr-2"></span>
-                Prioridade alta
-              </span>
-              <span class="flex items-center px-3 py-1 rounded-full bg-amber-50 text-amber-600 text-xs font-semibold">
-                <span class="w-2 h-2 rounded-full bg-amber-500 mr-2"></span>
-                Prioridade média
-              </span>
-            </div>
-          </div>
-          <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="p-4 rounded-2xl border border-gray-100 hover:border-blue-200 transition-all">
-              <div class="flex items-center justify-between mb-3">
-                <div class="flex items-center space-x-3">
-                  <div class="w-10 h-10 rounded-2xl bg-blue-50 text-blue-600 flex items-center justify-center">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.59 14.37L18 16.78 19.41 15.37 17 12.95M11 5H6a2 2 0 00-2 2v13l4-2 4 2V7a2 2 0 00-2-2h1" />
-                    </svg>
-                  </div>
-                  <div>
-                    <div class="text-sm font-semibold text-gray-900">Reunião com responsáveis</div>
-                    <div class="text-xs text-gray-500">Família Sousa Lima • até 18/04</div>
-                  </div>
-                </div>
-                <span class="px-2 py-1 rounded-full bg-emerald-100 text-emerald-600 text-[11px] font-semibold">Alta</span>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4" *ngIf="familias.length > 0">
+          <div
+            *ngFor="let familia of familias"
+            class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all"
+          >
+            <div class="flex items-start justify-between">
+              <div>
+                <h2 class="text-lg font-semibold text-gray-900 mb-1">Família de {{ obterResponsavel(familia) }}</h2>
+                <p class="text-sm text-gray-500">
+                  {{ familia.bairro }} • {{ dataCadastro(familia) || 'Data não disponível' }}
+                </p>
               </div>
-              <p class="text-sm text-gray-500">Confirmar presença em evento comunitário e alinhar demandas locais prioritárias.</p>
+              <span class="px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold">
+                {{ obterTotalMembros(familia) }} membros
+              </span>
             </div>
-
-            <div class="p-4 rounded-2xl border border-gray-100 hover:border-blue-200 transition-all">
-              <div class="flex items-center justify-between mb-3">
-                <div class="flex items-center space-x-3">
-                  <div class="w-10 h-10 rounded-2xl bg-blue-50 text-blue-600 flex items-center justify-center">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m6 4h6M9 21l-6-6h12l-6 6z" />
-                    </svg>
-                  </div>
-                  <div>
-                    <div class="text-sm font-semibold text-gray-900">Mapeamento de novos líderes</div>
-                    <div class="text-xs text-gray-500">Região Leste • até 22/04</div>
-                  </div>
-                </div>
-                <span class="px-2 py-1 rounded-full bg-amber-100 text-amber-600 text-[11px] font-semibold">Média</span>
+            <div class="mt-4 grid grid-cols-3 gap-4 text-center">
+              <div>
+                <div class="text-2xl font-bold text-gray-900">{{ obterTotalMembros(familia) }}</div>
+                <div class="text-xs text-gray-500">Integrantes</div>
               </div>
-              <p class="text-sm text-gray-500">Identificar famílias emergentes com potencial de mobilização para próximas agendas.</p>
+              <div>
+                <div class="text-2xl font-bold text-gray-900">
+                  {{ familia.membros.filter(m => m.probabilidadeVoto === 'Alta').length }}
+                </div>
+                <div class="text-xs text-gray-500">Alta probabilidade</div>
+              </div>
+              <div>
+                <div class="text-2xl font-bold text-gray-900">
+                  {{ familia.membros.filter(m => m.probabilidadeVoto === 'Baixa').length }}
+                </div>
+                <div class="text-xs text-gray-500">Baixa probabilidade</div>
+              </div>
+            </div>
+            <div class="mt-5 flex items-center justify-between">
+              <div class="flex -space-x-2">
+                <ng-container *ngFor="let membro of membrosSecundarios(familia) | slice:0:2">
+                  <div
+                    class="w-8 h-8 rounded-full bg-blue-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-blue-600"
+                    [ngClass]="{
+                      'bg-purple-100 text-purple-600': membro.probabilidadeVoto === 'Alta',
+                      'bg-amber-100 text-amber-600': membro.probabilidadeVoto === 'Média',
+                      'bg-gray-100 text-gray-600': membro.probabilidadeVoto === 'Baixa'
+                    }"
+                    [title]="membro.nomeCompleto"
+                  >
+                    {{ obterIniciais(membro.nomeCompleto) }}
+                  </div>
+                </ng-container>
+                <div
+                  *ngIf="membrosSecundarios(familia).length > 2"
+                  class="w-8 h-8 rounded-full bg-gray-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-gray-500"
+                >
+                  +{{ membrosSecundarios(familia).length - 2 }}
+                </div>
+              </div>
+              <div class="text-sm text-gray-500 text-right">
+                <div class="font-semibold text-gray-700">Contato</div>
+                <div>{{ familia.telefone || 'Telefone não informado' }}</div>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FamiliasService, FamiliaResponse } from './familias.service';
 
 @Component({
 
@@ -8,27 +9,101 @@ import { Component } from '@angular/core';
   templateUrl: './familias.component.html',
   styleUrls: ['./familias.component.css']
 })
-export class FamiliasComponent {
-  destaques = [
-    {
-      titulo: 'Famílias cadastradas',
-      valor: '128',
-      variacao: '+8,4%',
-      descricao: 'crescimento nos últimos 30 dias'
-    },
-    {
-      titulo: 'Responsáveis ativos',
-      valor: '94',
-      variacao: '+5,1%',
-      descricao: 'com engajamento confirmado'
-    },
-    {
-      titulo: 'Novos cadastros',
-      valor: '12',
-      variacao: '+3 nesta semana',
-      descricao: 'aguardando validação'
-    }
-  ];
-
+export class FamiliasComponent implements OnInit {
+  destaques: { titulo: string; valor: string; variacao: string; descricao: string }[] = [];
   filtros = ['Todos', 'Zona Norte', 'Zona Sul', 'Zona Leste', 'Zona Oeste'];
+  familias: FamiliaResponse[] = [];
+  carregando = false;
+  erroCarregamento = '';
+
+  constructor(private readonly familiasService: FamiliasService) {}
+
+  ngOnInit(): void {
+    this.carregarFamilias();
+  }
+
+  obterIniciais(nome: string): string {
+    if (!nome) {
+      return 'NA';
+    }
+
+    const partes = nome.trim().split(/\s+/);
+    if (partes.length === 1) {
+      return partes[0].substring(0, 2).toUpperCase();
+    }
+
+    return (partes[0][0] + partes[partes.length - 1][0]).toUpperCase();
+  }
+
+  obterResponsavel(familia: FamiliaResponse): string {
+    const responsavel = familia.membros.find(membro => membro.responsavelPrincipal);
+    return responsavel?.nomeCompleto || 'Responsável não informado';
+  }
+
+  obterTotalMembros(familia: FamiliaResponse): number {
+    return familia.membros.length;
+  }
+
+  membrosSecundarios(familia: FamiliaResponse): FamiliaResponse['membros'] {
+    return familia.membros.filter(membro => !membro.responsavelPrincipal);
+  }
+
+  dataCadastro(familia: FamiliaResponse): string {
+    const data = new Date(familia.criadoEm);
+    if (Number.isNaN(data.getTime())) {
+      return '';
+    }
+    return data.toLocaleDateString();
+  }
+
+  private carregarFamilias(): void {
+    this.carregando = true;
+    this.erroCarregamento = '';
+    this.familiasService.listarFamilias().subscribe({
+      next: familias => {
+        this.familias = familias;
+        this.atualizarDestaques();
+        this.carregando = false;
+      },
+      error: erro => {
+        console.error('Erro ao carregar famílias', erro);
+        this.erroCarregamento = 'Não foi possível carregar as famílias cadastradas.';
+        this.carregando = false;
+      }
+    });
+  }
+
+  private atualizarDestaques(): void {
+    const totalFamilias = this.familias.length;
+    const responsaveisAtivos = this.familias.filter(familia =>
+      familia.membros.some(membro => membro.responsavelPrincipal)
+    ).length;
+    const seteDiasAtras = new Date();
+    seteDiasAtras.setDate(seteDiasAtras.getDate() - 7);
+    const novosCadastros = this.familias.filter(familia => {
+      const data = new Date(familia.criadoEm);
+      return data >= seteDiasAtras;
+    }).length;
+
+    this.destaques = [
+      {
+        titulo: 'Famílias cadastradas',
+        valor: totalFamilias.toString(),
+        variacao: totalFamilias > 0 ? `+${totalFamilias}` : '+0',
+        descricao: 'total registrado na base'
+      },
+      {
+        titulo: 'Responsáveis ativos',
+        valor: responsaveisAtivos.toString(),
+        variacao: responsaveisAtivos > 0 ? `+${responsaveisAtivos}` : '+0',
+        descricao: 'famílias com responsável definido'
+      },
+      {
+        titulo: 'Novos cadastros',
+        valor: novosCadastros.toString(),
+        variacao: `+${novosCadastros} nesta semana`,
+        descricao: 'entradas nos últimos 7 dias'
+      }
+    ];
+  }
 }

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface FamiliaMembroPayload {
+  nomeCompleto: string;
+  dataNascimento: string | null;
+  profissao: string | null;
+  parentesco: string;
+  responsavelPrincipal: boolean;
+  probabilidadeVoto: string;
+  telefone: string | null;
+}
+
+export interface FamiliaPayload {
+  endereco: string;
+  bairro: string;
+  telefone: string;
+  membros: FamiliaMembroPayload[];
+}
+
+export interface FamiliaMembroResponse {
+  id: number;
+  nomeCompleto: string;
+  dataNascimento: string | null;
+  profissao: string | null;
+  parentesco: string;
+  responsavelPrincipal: boolean;
+  probabilidadeVoto: string;
+  telefone: string | null;
+  criadoEm: string;
+}
+
+export interface FamiliaResponse {
+  id: number;
+  endereco: string;
+  bairro: string;
+  telefone: string;
+  criadoEm: string;
+  membros: FamiliaMembroResponse[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class FamiliasService {
+  private readonly apiUrl = 'http://localhost:3000/api/familias';
+
+  constructor(private readonly http: HttpClient) {}
+
+  listarFamilias(): Observable<FamiliaResponse[]> {
+    return this.http.get<FamiliaResponse[]>(this.apiUrl);
+  }
+
+  criarFamilia(payload: FamiliaPayload): Observable<{ success: boolean; id: number }> {
+    return this.http.post<{ success: boolean; id: number }>(this.apiUrl, payload);
+  }
+}

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -63,7 +63,7 @@
             class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50 text-gray-600 cursor-not-allowed"
             disabled
           />
-          <p class="text-xs text-gray-500 mt-2">O responsável é definido ao selecionar o papel &quot;Responsável&quot; para um membro.</p>
+          <p class="text-xs text-gray-500 mt-2">O responsável é definido ao marcar a opção de responsável em um dos membros cadastrados.</p>
         </div>
 
         <div class="md:col-span-2">
@@ -184,27 +184,30 @@
 
             <div>
               <label class="block text-sm font-semibold text-gray-700 mb-2">Grau de Parentesco *</label>
-              <input
-                type="text"
+              <select
                 class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
                 [(ngModel)]="membro.parentesco"
                 name="parentesco_{{ i }}"
-                placeholder="Ex.: Pai, Mãe, Filho(a), Esposo(a)"
-              />
+              >
+                <option value="">Selecione o parentesco</option>
+                <option *ngFor="let parentesco of grausParentesco" [value]="parentesco">{{ parentesco }}</option>
+              </select>
             </div>
 
-            <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">Papel na Família *</label>
-              <select
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [ngModel]="membro.papel"
-                (ngModelChange)="atualizarPapel(i, $event)"
-                name="papel_{{ i }}"
-              >
-                <option value="">Selecione o papel</option>
-                <option value="Responsável">Responsável</option>
-                <option value="Membro">Membro</option>
-              </select>
+            <div class="md:col-span-2">
+              <div class="flex items-center space-x-3 mt-2 md:mt-0">
+                <input
+                  type="checkbox"
+                  class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  [id]="'responsavel_' + i"
+                  [checked]="membro.responsavel"
+                  (change)="definirResponsavel(i, $event.target.checked)"
+                />
+                <label [for]="'responsavel_' + i" class="text-sm font-semibold text-gray-700">
+                  Responsável pela família
+                </label>
+              </div>
+              <p class="text-xs text-gray-500 mt-2">Somente um membro pode ser o responsável principal por vez.</p>
             </div>
 
             <div>
@@ -348,9 +351,9 @@
               </span>
               <span
                 class="px-2 py-1 text-xs font-medium rounded-full"
-                [ngClass]="membro.papel === 'Responsável' ? 'bg-purple-100 text-purple-700' : 'bg-gray-100 text-gray-700'"
+                [ngClass]="membro.responsavel ? 'bg-purple-100 text-purple-700' : 'bg-gray-100 text-gray-700'"
               >
-                {{ membro.papel || 'Papel não definido' }}
+                {{ membro.responsavel ? 'Responsável' : 'Membro' }}
               </span>
             </div>
             <div class="flex items-center space-x-2 text-sm text-gray-500 mt-1">


### PR DESCRIPTION
## Resumo
- adiciona tipo enumerado para grau de parentesco e remove o antigo papel, garantindo consistência no esquema de membros
- expõe endpoints REST para criar e listar famílias armazenando dados no PostgreSQL
- conecta o fluxo do frontend ao backend com serviço HTTP, nova listagem dinâmica e formulário ajustado com checkbox de responsável

## Testes
- `npm test` (backend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68cf737b442c832894fb7cf03a85c090