### PR TITLE
Corrige contagem de probabilidades em famílias

### DIFF
--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -100,13 +100,13 @@
               </div>
               <div>
                 <div class="text-2xl font-bold text-gray-900">
-                  {{ familia.membros.filter(m => m.probabilidadeVoto === 'Alta').length }}
+                  {{ contarMembrosPorProbabilidade(familia, 'Alta') }}
                 </div>
                 <div class="text-xs text-gray-500">Alta probabilidade</div>
               </div>
               <div>
                 <div class="text-2xl font-bold text-gray-900">
-                  {{ familia.membros.filter(m => m.probabilidadeVoto === 'Baixa').length }}
+                  {{ contarMembrosPorProbabilidade(familia, 'Baixa') }}
                 </div>
                 <div class="text-xs text-gray-500">Baixa probabilidade</div>
               </div>

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -44,6 +44,13 @@ export class FamiliasComponent implements OnInit {
     return familia.membros.length;
   }
 
+  contarMembrosPorProbabilidade(
+    familia: FamiliaResponse,
+    probabilidade: 'Alta' | 'Média' | 'Baixa'
+  ): number {
+    return familia.membros.filter(membro => membro.probabilidadeVoto === probabilidade).length;
+  }
+
   membrosSecundarios(familia: FamiliaResponse): FamiliaResponse['membros'] {
     return familia.membros.filter(membro => !membro.responsavelPrincipal);
   }


### PR DESCRIPTION
## Summary
- cria método no componente de famílias para contar membros por probabilidade de voto
- atualiza o template para usar o método e remover expressões inválidas

## Testing
- npm test (frontend)
- npm test (backend)

------
https://chatgpt.com/codex/tasks/task_e_68cf7a61551c8328b7af2a457eb83c32