### PR TITLE
Cria backend Spring Boot equivalente ao Node/Express

### DIFF
--- a/spring-backend/pom.xml
+++ b/spring-backend/pom.xml
@@ -1,0 +1,67 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.gestorpolitico</groupId>
+  <artifactId>spring-backend</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>spring-backend</name>
+  <description>API REST do Gestor Político</description>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.5.6</version>
+    <relativePath/>
+  </parent>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-backend/src/main/java/com/gestorpolitico/GestorPoliticoApplication.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/GestorPoliticoApplication.java
@@ -1,0 +1,11 @@
+package com.gestorpolitico;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GestorPoliticoApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(GestorPoliticoApplication.class, args);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/config/DataInitializer.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/config/DataInitializer.java
@@ -1,0 +1,23 @@
+package com.gestorpolitico.config;
+
+import com.gestorpolitico.domain.Login;
+import com.gestorpolitico.repository.LoginRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+  private final LoginRepository loginRepository;
+
+  @Override
+  public void run(String... args) {
+    loginRepository.findByUsuario("admin@plataforma.gov")
+      .orElseGet(() -> loginRepository.save(Login.builder()
+        .usuario("admin@plataforma.gov")
+        .senha("123456")
+        .nome("Administrador")
+        .build()));
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/domain/Familia.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/domain/Familia.java
@@ -1,0 +1,54 @@
+package com.gestorpolitico.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "familia")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Familia {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 255)
+  private String endereco;
+
+  @Column(nullable = false, length = 120)
+  private String bairro;
+
+  @Column(nullable = false, length = 30)
+  private String telefone;
+
+  @CreationTimestamp
+  @Column(name = "criado_em", nullable = false, updatable = false)
+  private LocalDateTime criadoEm;
+
+  @Builder.Default
+  @OneToMany(mappedBy = "familia", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<MembroFamilia> membros = new ArrayList<>();
+
+  public void adicionarMembro(MembroFamilia membro) {
+    membros.add(membro);
+    membro.setFamilia(this);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/domain/GrauParentesco.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/domain/GrauParentesco.java
@@ -1,0 +1,45 @@
+package com.gestorpolitico.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+
+public enum GrauParentesco {
+  PAI("Pai"),
+  MAE("Mãe"),
+  FILHO_A("Filho(a)"),
+  FILHA("Filha"),
+  FILHO("Filho"),
+  IRMAO_A("Irmão(ã)"),
+  PRIMO_A("Primo(a)"),
+  TIO_A("Tio(a)"),
+  SOBRINHO_A("Sobrinho(a)"),
+  CONJUGE("Cônjuge"),
+  AVO_O("Avô(ó)"),
+  ENTEADO_A("Enteado(a)"),
+  OUTRO("Outro");
+
+  private final String value;
+
+  GrauParentesco(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+
+  @JsonCreator
+  public static GrauParentesco fromValue(String value) {
+    return Arrays.stream(values())
+      .filter(item -> item.value.equalsIgnoreCase(value))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("Parentesco inválido: " + value));
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/domain/Login.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/domain/Login.java
@@ -1,0 +1,35 @@
+package com.gestorpolitico.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "login")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Login {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, length = 255)
+  private String usuario;
+
+  @Column(nullable = false, length = 255)
+  private String senha;
+
+  @Column(nullable = false, length = 255)
+  private String nome;
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/domain/MembroFamilia.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/domain/MembroFamilia.java
@@ -1,0 +1,61 @@
+package com.gestorpolitico.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "membro_familia")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MembroFamilia {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "familia_id", nullable = false)
+  private Familia familia;
+
+  @Column(name = "nome_completo", nullable = false, length = 255)
+  private String nomeCompleto;
+
+  @Column(name = "data_nascimento")
+  private LocalDate dataNascimento;
+
+  @Column(length = 255)
+  private String profissao;
+
+  @Column(nullable = false, length = 50)
+  private GrauParentesco parentesco;
+
+  @Column(name = "responsavel_principal", nullable = false)
+  private boolean responsavelPrincipal;
+
+  @Column(name = "probabilidade_voto", nullable = false, length = 20)
+  private String probabilidadeVoto;
+
+  @Column(length = 30)
+  private String telefone;
+
+  @CreationTimestamp
+  @Column(name = "criado_em", nullable = false, updatable = false)
+  private LocalDateTime criadoEm;
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/domain/converter/GrauParentescoConverter.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/domain/converter/GrauParentescoConverter.java
@@ -1,0 +1,18 @@
+package com.gestorpolitico.domain.converter;
+
+import com.gestorpolitico.domain.GrauParentesco;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class GrauParentescoConverter implements AttributeConverter<GrauParentesco, String> {
+  @Override
+  public String convertToDatabaseColumn(GrauParentesco atributo) {
+    return atributo != null ? atributo.getValue() : null;
+  }
+
+  @Override
+  public GrauParentesco convertToEntityAttribute(String coluna) {
+    return coluna != null ? GrauParentesco.fromValue(coluna) : null;
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/repository/FamiliaRepository.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/repository/FamiliaRepository.java
@@ -1,0 +1,11 @@
+package com.gestorpolitico.repository;
+
+import com.gestorpolitico.domain.Familia;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FamiliaRepository extends JpaRepository<Familia, Long> {
+  @EntityGraph(attributePaths = "membros")
+  List<Familia> findAllByOrderByCriadoEmDesc();
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/repository/LoginRepository.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/repository/LoginRepository.java
@@ -1,0 +1,11 @@
+package com.gestorpolitico.repository;
+
+import com.gestorpolitico.domain.Login;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoginRepository extends JpaRepository<Login, Long> {
+  Optional<Login> findByUsuarioAndSenha(String usuario, String senha);
+
+  Optional<Login> findByUsuario(String usuario);
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/service/FamiliaService.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/service/FamiliaService.java
@@ -1,0 +1,98 @@
+package com.gestorpolitico.service;
+
+import com.gestorpolitico.domain.Familia;
+import com.gestorpolitico.domain.GrauParentesco;
+import com.gestorpolitico.domain.MembroFamilia;
+import com.gestorpolitico.repository.FamiliaRepository;
+import com.gestorpolitico.web.dto.FamiliaRequest;
+import com.gestorpolitico.web.dto.FamiliaResponse;
+import com.gestorpolitico.web.dto.MembroFamiliaRequest;
+import com.gestorpolitico.web.dto.MembroFamiliaResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class FamiliaService {
+  private final FamiliaRepository familiaRepository;
+
+  public List<FamiliaResponse> listar() {
+    return familiaRepository.findAllByOrderByCriadoEmDesc()
+      .stream()
+      .map(this::converterParaResponse)
+      .toList();
+  }
+
+  @Transactional
+  public FamiliaResponse criar(FamiliaRequest request) {
+    validarMembros(request.membros());
+
+    Familia familia = Familia.builder()
+      .endereco(request.endereco())
+      .bairro(request.bairro())
+      .telefone(request.telefone())
+      .build();
+
+    request.membros().stream()
+      .map(this::converterParaEntidade)
+      .forEach(familia::adicionarMembro);
+
+    return converterParaResponse(familiaRepository.save(familia));
+  }
+
+  private void validarMembros(List<MembroFamiliaRequest> membros) {
+    long quantidadeResponsaveis = membros.stream()
+      .filter(membro -> Boolean.TRUE.equals(membro.responsavelPrincipal()))
+      .count();
+
+    if (quantidadeResponsaveis == 0) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Defina um responsável principal para a família.");
+    }
+
+    if (quantidadeResponsaveis > 1) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A família deve possuir apenas um responsável principal.");
+    }
+  }
+
+  private MembroFamilia converterParaEntidade(MembroFamiliaRequest request) {
+    return MembroFamilia.builder()
+      .nomeCompleto(request.nomeCompleto())
+      .dataNascimento(request.dataNascimento())
+      .profissao(request.profissao())
+      .parentesco(GrauParentesco.fromValue(request.parentesco()))
+      .responsavelPrincipal(Boolean.TRUE.equals(request.responsavelPrincipal()))
+      .probabilidadeVoto(request.probabilidadeVoto())
+      .telefone(request.telefone())
+      .build();
+  }
+
+  private FamiliaResponse converterParaResponse(Familia familia) {
+    List<MembroFamiliaResponse> membros = familia.getMembros().stream()
+      .map(membro -> new MembroFamiliaResponse(
+        membro.getId(),
+        membro.getNomeCompleto(),
+        membro.getDataNascimento(),
+        membro.getProfissao(),
+        membro.getParentesco() != null ? membro.getParentesco().getValue() : null,
+        membro.isResponsavelPrincipal(),
+        membro.getProbabilidadeVoto(),
+        membro.getTelefone(),
+        membro.getCriadoEm()
+      ))
+      .collect(Collectors.toList());
+
+    return new FamiliaResponse(
+      familia.getId(),
+      familia.getEndereco(),
+      familia.getBairro(),
+      familia.getTelefone(),
+      familia.getCriadoEm(),
+      membros
+    );
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/service/LoginService.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/service/LoginService.java
@@ -1,0 +1,21 @@
+package com.gestorpolitico.service;
+
+import com.gestorpolitico.repository.LoginRepository;
+import com.gestorpolitico.web.dto.LoginRequest;
+import com.gestorpolitico.web.dto.LoginResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+  private final LoginRepository loginRepository;
+
+  public LoginResponse autenticar(LoginRequest request) {
+    return loginRepository.findByUsuarioAndSenha(request.usuario(), request.senha())
+      .map(login -> new LoginResponse(login.getId(), login.getUsuario(), login.getNome()))
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Credenciais inválidas"));
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/FamiliaController.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/FamiliaController.java
@@ -1,0 +1,30 @@
+package com.gestorpolitico.web;
+
+import com.gestorpolitico.service.FamiliaService;
+import com.gestorpolitico.web.dto.FamiliaRequest;
+import com.gestorpolitico.web.dto.FamiliaResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/familias")
+@RequiredArgsConstructor
+public class FamiliaController {
+  private final FamiliaService familiaService;
+
+  @GetMapping
+  public List<FamiliaResponse> listar() {
+    return familiaService.listar();
+  }
+
+  @PostMapping
+  public FamiliaResponse criar(@Valid @RequestBody FamiliaRequest request) {
+    return familiaService.criar(request);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/LoginController.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/LoginController.java
@@ -1,0 +1,23 @@
+package com.gestorpolitico.web;
+
+import com.gestorpolitico.service.LoginService;
+import com.gestorpolitico.web.dto.LoginRequest;
+import com.gestorpolitico.web.dto.LoginResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class LoginController {
+  private final LoginService loginService;
+
+  @PostMapping("/login")
+  public LoginResponse autenticar(@Valid @RequestBody LoginRequest request) {
+    return loginService.autenticar(request);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/dto/FamiliaRequest.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/dto/FamiliaRequest.java
@@ -1,0 +1,21 @@
+package com.gestorpolitico.web.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record FamiliaRequest(
+  @NotBlank(message = "Informe o endereço")
+  @Size(max = 255)
+  String endereco,
+  @NotBlank(message = "Informe o bairro")
+  @Size(max = 120)
+  String bairro,
+  @NotBlank(message = "Informe o telefone")
+  @Size(max = 30)
+  String telefone,
+  @NotEmpty(message = "Informe ao menos um membro")
+  List<@Valid MembroFamiliaRequest> membros
+) {}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/dto/FamiliaResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/dto/FamiliaResponse.java
@@ -1,0 +1,13 @@
+package com.gestorpolitico.web.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FamiliaResponse(
+  Long id,
+  String endereco,
+  String bairro,
+  String telefone,
+  LocalDateTime criadoEm,
+  List<MembroFamiliaResponse> membros
+) {}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/dto/LoginRequest.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.gestorpolitico.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+  @NotBlank(message = "Informe o usuário")
+  String usuario,
+  @NotBlank(message = "Informe a senha")
+  String senha
+) {}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/dto/LoginResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/dto/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.gestorpolitico.web.dto;
+
+public record LoginResponse(
+  Long id,
+  String usuario,
+  String nome
+) {}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/dto/MembroFamiliaRequest.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/dto/MembroFamiliaRequest.java
@@ -1,0 +1,24 @@
+package com.gestorpolitico.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record MembroFamiliaRequest(
+  @NotBlank(message = "Informe o nome completo")
+  @Size(max = 255)
+  String nomeCompleto,
+  LocalDate dataNascimento,
+  @Size(max = 255)
+  String profissao,
+  @NotBlank(message = "Informe o grau de parentesco")
+  String parentesco,
+  @NotNull(message = "Informe se é o responsável principal")
+  Boolean responsavelPrincipal,
+  @NotBlank(message = "Informe a probabilidade de voto")
+  @Size(max = 20)
+  String probabilidadeVoto,
+  @Size(max = 30)
+  String telefone
+) {}

--- a/spring-backend/src/main/java/com/gestorpolitico/web/dto/MembroFamiliaResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/web/dto/MembroFamiliaResponse.java
@@ -1,0 +1,16 @@
+package com.gestorpolitico.web.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record MembroFamiliaResponse(
+  Long id,
+  String nomeCompleto,
+  LocalDate dataNascimento,
+  String profissao,
+  String parentesco,
+  boolean responsavelPrincipal,
+  String probabilidadeVoto,
+  String telefone,
+  LocalDateTime criadoEm
+) {}

--- a/spring-backend/src/main/resources/application.yml
+++ b/spring-backend/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/gestor_politico
+    username: postgres
+    password: admin
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+  jackson:
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
+server:
+  port: 8080
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs


### PR DESCRIPTION
## Resumo
- adiciona projeto Maven Spring Boot 3.5.6 com Java 17 e dependências solicitadas
- mapeia entidades Login, Família e Membro de Família com serviços e controladores REST compatíveis com a API Node/Express
- configura PostgreSQL via application.yml e inicializa usuário administrador padrão

## Testes
- npm test (backend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d01dc2909c8328be8af67763e096ed