### PR TITLE
Adicionar serviço de autenticação em Spring Boot

### DIFF
--- a/backend-spring/src/main/java/br/com/gestorpolitico/controller/UsuarioController.java
+++ b/backend-spring/src/main/java/br/com/gestorpolitico/controller/UsuarioController.java
@@ -1,0 +1,28 @@
+package br.com.gestorpolitico.controller;
+
+import br.com.gestorpolitico.dto.LoginRequestDto;
+import br.com.gestorpolitico.dto.UsuarioAutenticadoDto;
+import br.com.gestorpolitico.service.UsuarioService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/usuarios")
+public class UsuarioController {
+  private final UsuarioService usuarioService;
+
+  public UsuarioController(UsuarioService usuarioService) {
+    this.usuarioService = usuarioService;
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<UsuarioAutenticadoDto> login(@Valid @RequestBody LoginRequestDto request) {
+    UsuarioAutenticadoDto usuarioAutenticado =
+      usuarioService.autenticar(request.usuario(), request.senha());
+    return ResponseEntity.ok(usuarioAutenticado);
+  }
+}

--- a/backend-spring/src/main/java/br/com/gestorpolitico/dto/LoginRequestDto.java
+++ b/backend-spring/src/main/java/br/com/gestorpolitico/dto/LoginRequestDto.java
@@ -1,0 +1,8 @@
+package br.com.gestorpolitico.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDto(
+  @NotBlank(message = "O usuário é obrigatório") String usuario,
+  @NotBlank(message = "A senha é obrigatória") String senha
+) {}

--- a/backend-spring/src/main/java/br/com/gestorpolitico/dto/UsuarioAutenticadoDto.java
+++ b/backend-spring/src/main/java/br/com/gestorpolitico/dto/UsuarioAutenticadoDto.java
@@ -1,0 +1,3 @@
+package br.com.gestorpolitico.dto;
+
+public record UsuarioAutenticadoDto(Long id, String usuario, String nome) {}

--- a/backend-spring/src/main/java/br/com/gestorpolitico/exception/CredenciaisInvalidasException.java
+++ b/backend-spring/src/main/java/br/com/gestorpolitico/exception/CredenciaisInvalidasException.java
@@ -1,0 +1,7 @@
+package br.com.gestorpolitico.exception;
+
+public class CredenciaisInvalidasException extends RuntimeException {
+  public CredenciaisInvalidasException() {
+    super("Credenciais inválidas");
+  }
+}

--- a/backend-spring/src/main/java/br/com/gestorpolitico/handler/ApiExceptionHandler.java
+++ b/backend-spring/src/main/java/br/com/gestorpolitico/handler/ApiExceptionHandler.java
@@ -1,0 +1,20 @@
+package br.com.gestorpolitico.handler;
+
+import br.com.gestorpolitico.exception.CredenciaisInvalidasException;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+  @ExceptionHandler(CredenciaisInvalidasException.class)
+  public ResponseEntity<Map<String, Object>> handleCredenciaisInvalidas(
+    CredenciaisInvalidasException ex
+  ) {
+    return ResponseEntity
+      .status(HttpStatus.UNAUTHORIZED)
+      .body(Map.of("success", false, "message", ex.getMessage()));
+  }
+}

--- a/backend-spring/src/main/java/br/com/gestorpolitico/service/UsuarioService.java
+++ b/backend-spring/src/main/java/br/com/gestorpolitico/service/UsuarioService.java
@@ -1,0 +1,7 @@
+package br.com.gestorpolitico.service;
+
+import br.com.gestorpolitico.dto.UsuarioAutenticadoDto;
+
+public interface UsuarioService {
+  UsuarioAutenticadoDto autenticar(String usuario, String senha);
+}

--- a/backend-spring/src/main/java/br/com/gestorpolitico/service/impl/UsuarioServiceImpl.java
+++ b/backend-spring/src/main/java/br/com/gestorpolitico/service/impl/UsuarioServiceImpl.java
@@ -1,0 +1,48 @@
+package br.com.gestorpolitico.service.impl;
+
+import br.com.gestorpolitico.dto.UsuarioAutenticadoDto;
+import br.com.gestorpolitico.exception.CredenciaisInvalidasException;
+import br.com.gestorpolitico.service.UsuarioService;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UsuarioServiceImpl implements UsuarioService {
+  private static final String LOGIN_SQL =
+    "SELECT id, usuario, nome FROM login WHERE usuario = ? AND senha = ?";
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public UsuarioServiceImpl(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public UsuarioAutenticadoDto autenticar(String usuario, String senha) {
+    try {
+      return jdbcTemplate.queryForObject(
+        LOGIN_SQL,
+        new UsuarioAutenticadoRowMapper(),
+        usuario,
+        senha
+      );
+    } catch (EmptyResultDataAccessException ex) {
+      throw new CredenciaisInvalidasException();
+    }
+  }
+
+  private static class UsuarioAutenticadoRowMapper implements RowMapper<UsuarioAutenticadoDto> {
+    @Override
+    public UsuarioAutenticadoDto mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return new UsuarioAutenticadoDto(
+        rs.getLong("id"),
+        rs.getString("usuario"),
+        rs.getString("nome")
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Sumário
- criar serviço e implementação para autenticação de usuários com JDBC
- adicionar DTOs, exceção e handler para respostas HTTP consistentes
- expor endpoint de login no controller chamando apenas o service

## Testes
- npm test (backend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d01dcbed0883288dc01f1214d0f1fb