### PR TITLE
Adiciona repositories JPA

### DIFF
--- a/backend/spring/src/main/java/com/gestorpolitico/repository/FamiliaRepository.java
+++ b/backend/spring/src/main/java/com/gestorpolitico/repository/FamiliaRepository.java
@@ -1,0 +1,18 @@
+package com.gestorpolitico.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.gestorpolitico.domain.Familia;
+
+public interface FamiliaRepository extends JpaRepository<Familia, Long> {
+  @Query("SELECT DISTINCT f FROM Familia f LEFT JOIN FETCH f.membros m ORDER BY f.criadoEm DESC")
+  List<Familia> findAllWithMembros();
+
+  @Query("SELECT f FROM Familia f LEFT JOIN FETCH f.membros m WHERE f.id = :id")
+  Optional<Familia> findByIdWithMembros(@Param("id") Long id);
+}

--- a/backend/spring/src/main/java/com/gestorpolitico/repository/LoginRepository.java
+++ b/backend/spring/src/main/java/com/gestorpolitico/repository/LoginRepository.java
@@ -1,0 +1,13 @@
+package com.gestorpolitico.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.gestorpolitico.domain.Login;
+
+public interface LoginRepository extends JpaRepository<Login, Long> {
+  Optional<Login> findByUsuario(String usuario);
+
+  Optional<Login> findByUsuarioAndSenha(String usuario, String senha);
+}

--- a/backend/spring/src/main/java/com/gestorpolitico/repository/MembroFamiliaRepository.java
+++ b/backend/spring/src/main/java/com/gestorpolitico/repository/MembroFamiliaRepository.java
@@ -1,0 +1,16 @@
+package com.gestorpolitico.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.gestorpolitico.domain.MembroFamilia;
+
+public interface MembroFamiliaRepository extends JpaRepository<MembroFamilia, Long> {
+  List<MembroFamilia> findByFamiliaId(Long familiaId);
+
+  boolean existsByFamiliaIdAndResponsavelPrincipalTrue(Long familiaId);
+
+  Optional<MembroFamilia> findByFamiliaIdAndResponsavelPrincipalTrue(Long familiaId);
+}


### PR DESCRIPTION
## Resumo
- cria interfaces Spring Data JPA para Login, Família e MembroFamilia
- adiciona consultas JPQL para recuperar famílias com seus membros associados

## Testes
- npm test (backend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d01dd5e99c8328bdff744ecbc3f7b0