### PR TITLE
Adiciona backend Spring Boot com validações e segurança

### DIFF
--- a/spring-backend/pom.xml
+++ b/spring-backend/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath />
+  </parent>
+
+  <groupId>com.gestorpolitico</groupId>
+  <artifactId>spring-backend</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>spring-backend</name>
+  <description>Conversão do backend Express para Spring Boot</description>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/SpringBackendApplication.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/SpringBackendApplication.java
@@ -1,0 +1,11 @@
+package com.gestorpolitico.springbackend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringBackendApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(SpringBackendApplication.class, args);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/config/SecurityConfig.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.gestorpolitico.springbackend.config;
+
+import com.gestorpolitico.springbackend.security.BearerlessAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+  @Bean
+  public SecurityFilterChain securityFilterChain(
+    HttpSecurity http,
+    BearerlessAuthenticationFilter authenticationFilter
+  ) throws Exception {
+    http
+      .csrf(csrf -> csrf.disable())
+      .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+      .authorizeHttpRequests(auth -> auth
+        .requestMatchers(HttpMethod.POST, "/api/login").permitAll()
+        .anyRequest().authenticated()
+      )
+      .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/controller/FamiliaController.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/controller/FamiliaController.java
@@ -1,0 +1,35 @@
+package com.gestorpolitico.springbackend.controller;
+
+import com.gestorpolitico.springbackend.dto.FamiliaRequest;
+import com.gestorpolitico.springbackend.dto.FamiliaResponse;
+import com.gestorpolitico.springbackend.service.FamiliaService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/familias")
+public class FamiliaController {
+  private final FamiliaService familiaService;
+
+  public FamiliaController(FamiliaService familiaService) {
+    this.familiaService = familiaService;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<FamiliaResponse>> listar() {
+    return ResponseEntity.ok(familiaService.listarFamilias());
+  }
+
+  @PostMapping
+  public ResponseEntity<FamiliaResponse> criar(@Valid @RequestBody FamiliaRequest request) {
+    FamiliaResponse response = familiaService.criarFamilia(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/controller/LoginController.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/controller/LoginController.java
@@ -1,0 +1,33 @@
+package com.gestorpolitico.springbackend.controller;
+
+import com.gestorpolitico.springbackend.dto.ErrorResponse;
+import com.gestorpolitico.springbackend.dto.LoginRequest;
+import com.gestorpolitico.springbackend.dto.LoginResponse;
+import com.gestorpolitico.springbackend.service.LoginService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class LoginController {
+  private final LoginService loginService;
+
+  public LoginController(LoginService loginService) {
+    this.loginService = loginService;
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<?> autenticar(@Valid @RequestBody LoginRequest request) {
+    return loginService
+      .autenticar(request.getUsuario(), request.getSenha())
+      .<ResponseEntity<?>>map(ResponseEntity::ok)
+      .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+          new ErrorResponse(false, "Credenciais inválidas.", null)
+        ));
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/ErrorResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.gestorpolitico.springbackend.dto;
+
+import java.util.List;
+
+public class ErrorResponse {
+  private final boolean success;
+  private final String message;
+  private final List<String> errors;
+
+  public ErrorResponse(boolean success, String message, List<String> errors) {
+    this.success = success;
+    this.message = message;
+    this.errors = errors;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public List<String> getErrors() {
+    return errors;
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/FamiliaRequest.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/FamiliaRequest.java
@@ -1,0 +1,68 @@
+package com.gestorpolitico.springbackend.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public class FamiliaRequest {
+  @NotBlank(message = "O endereço é obrigatório.")
+  @Size(max = 255, message = "O endereço deve ter no máximo 255 caracteres.")
+  private String endereco;
+
+  @NotBlank(message = "O bairro é obrigatório.")
+  @Size(max = 120, message = "O bairro deve ter no máximo 120 caracteres.")
+  private String bairro;
+
+  @NotBlank(message = "O telefone é obrigatório.")
+  @Size(max = 30, message = "O telefone deve ter no máximo 30 caracteres.")
+  private String telefone;
+
+  @NotEmpty(message = "Informe ao menos um membro da família.")
+  @Valid
+  private List<MembroFamiliaRequest> membros;
+
+  public String getEndereco() {
+    return endereco;
+  }
+
+  public void setEndereco(String endereco) {
+    this.endereco = endereco;
+  }
+
+  public String getBairro() {
+    return bairro;
+  }
+
+  public void setBairro(String bairro) {
+    this.bairro = bairro;
+  }
+
+  public String getTelefone() {
+    return telefone;
+  }
+
+  public void setTelefone(String telefone) {
+    this.telefone = telefone;
+  }
+
+  public List<MembroFamiliaRequest> getMembros() {
+    return membros;
+  }
+
+  public void setMembros(List<MembroFamiliaRequest> membros) {
+    this.membros = membros;
+  }
+
+  @AssertTrue(message = "Defina um responsável principal para a família.")
+  public boolean isPossuiResponsavelPrincipal() {
+    if (membros == null || membros.isEmpty()) {
+      return false;
+    }
+    return membros.stream()
+      .filter(membro -> membro != null)
+      .anyMatch(membro -> Boolean.TRUE.equals(membro.getResponsavelPrincipal()));
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/FamiliaResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/FamiliaResponse.java
@@ -1,0 +1,61 @@
+package com.gestorpolitico.springbackend.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class FamiliaResponse {
+  private Long id;
+  private String endereco;
+  private String bairro;
+  private String telefone;
+  private OffsetDateTime criadoEm;
+  private List<MembroFamiliaResponse> membros;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getEndereco() {
+    return endereco;
+  }
+
+  public void setEndereco(String endereco) {
+    this.endereco = endereco;
+  }
+
+  public String getBairro() {
+    return bairro;
+  }
+
+  public void setBairro(String bairro) {
+    this.bairro = bairro;
+  }
+
+  public String getTelefone() {
+    return telefone;
+  }
+
+  public void setTelefone(String telefone) {
+    this.telefone = telefone;
+  }
+
+  public OffsetDateTime getCriadoEm() {
+    return criadoEm;
+  }
+
+  public void setCriadoEm(OffsetDateTime criadoEm) {
+    this.criadoEm = criadoEm;
+  }
+
+  public List<MembroFamiliaResponse> getMembros() {
+    return membros;
+  }
+
+  public void setMembros(List<MembroFamiliaResponse> membros) {
+    this.membros = membros;
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/LoginRequest.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/LoginRequest.java
@@ -1,0 +1,27 @@
+package com.gestorpolitico.springbackend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+  @NotBlank(message = "O usuário é obrigatório.")
+  private String usuario;
+
+  @NotBlank(message = "A senha é obrigatória.")
+  private String senha;
+
+  public String getUsuario() {
+    return usuario;
+  }
+
+  public void setUsuario(String usuario) {
+    this.usuario = usuario;
+  }
+
+  public String getSenha() {
+    return senha;
+  }
+
+  public void setSenha(String senha) {
+    this.senha = senha;
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/LoginResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/LoginResponse.java
@@ -1,0 +1,49 @@
+package com.gestorpolitico.springbackend.dto;
+
+public class LoginResponse {
+  private final boolean success;
+  private final String message;
+  private final UsuarioDto user;
+
+  public LoginResponse(boolean success, String message, UsuarioDto user) {
+    this.success = success;
+    this.message = message;
+    this.user = user;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public UsuarioDto getUser() {
+    return user;
+  }
+
+  public static class UsuarioDto {
+    private final Long id;
+    private final String usuario;
+    private final String nome;
+
+    public UsuarioDto(Long id, String usuario, String nome) {
+      this.id = id;
+      this.usuario = usuario;
+      this.nome = nome;
+    }
+
+    public Long getId() {
+      return id;
+    }
+
+    public String getUsuario() {
+      return usuario;
+    }
+
+    public String getNome() {
+      return nome;
+    }
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/MembroFamiliaRequest.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/MembroFamiliaRequest.java
@@ -1,0 +1,95 @@
+package com.gestorpolitico.springbackend.dto;
+
+import com.gestorpolitico.springbackend.model.GrauParentesco;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class MembroFamiliaRequest {
+  @NotBlank(message = "O nome completo é obrigatório.")
+  @Size(max = 255, message = "O nome completo deve ter no máximo 255 caracteres.")
+  private String nomeCompleto;
+
+  @Pattern(
+    regexp = "^\\d{4}-\\d{2}-\\d{2}$",
+    message = "A data de nascimento deve estar no formato ISO (yyyy-MM-dd).",
+    groups = ValidacaoOpcional.class
+  )
+  private String dataNascimento;
+
+  @Size(max = 255, message = "A profissão deve ter no máximo 255 caracteres.")
+  private String profissao;
+
+  @NotNull(message = "O parentesco é obrigatório.")
+  private GrauParentesco parentesco;
+
+  @NotNull(message = "Informe se o membro é responsável principal.")
+  private Boolean responsavelPrincipal;
+
+  @NotBlank(message = "A probabilidade de voto é obrigatória.")
+  @Size(max = 20, message = "A probabilidade de voto deve ter no máximo 20 caracteres.")
+  private String probabilidadeVoto;
+
+  @Size(max = 30, message = "O telefone deve ter no máximo 30 caracteres.")
+  private String telefone;
+
+  public String getNomeCompleto() {
+    return nomeCompleto;
+  }
+
+  public void setNomeCompleto(String nomeCompleto) {
+    this.nomeCompleto = nomeCompleto;
+  }
+
+  public String getDataNascimento() {
+    return dataNascimento;
+  }
+
+  public void setDataNascimento(String dataNascimento) {
+    this.dataNascimento = dataNascimento;
+  }
+
+  public String getProfissao() {
+    return profissao;
+  }
+
+  public void setProfissao(String profissao) {
+    this.profissao = profissao;
+  }
+
+  public GrauParentesco getParentesco() {
+    return parentesco;
+  }
+
+  public void setParentesco(GrauParentesco parentesco) {
+    this.parentesco = parentesco;
+  }
+
+  public Boolean getResponsavelPrincipal() {
+    return responsavelPrincipal;
+  }
+
+  public void setResponsavelPrincipal(Boolean responsavelPrincipal) {
+    this.responsavelPrincipal = responsavelPrincipal;
+  }
+
+  public String getProbabilidadeVoto() {
+    return probabilidadeVoto;
+  }
+
+  public void setProbabilidadeVoto(String probabilidadeVoto) {
+    this.probabilidadeVoto = probabilidadeVoto;
+  }
+
+  public String getTelefone() {
+    return telefone;
+  }
+
+  public void setTelefone(String telefone) {
+    this.telefone = telefone;
+  }
+
+  public interface ValidacaoOpcional {
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/MembroFamiliaResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/dto/MembroFamiliaResponse.java
@@ -1,0 +1,87 @@
+package com.gestorpolitico.springbackend.dto;
+
+import java.time.OffsetDateTime;
+
+public class MembroFamiliaResponse {
+  private Long id;
+  private String nomeCompleto;
+  private String dataNascimento;
+  private String profissao;
+  private String parentesco;
+  private boolean responsavelPrincipal;
+  private String probabilidadeVoto;
+  private String telefone;
+  private OffsetDateTime criadoEm;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getNomeCompleto() {
+    return nomeCompleto;
+  }
+
+  public void setNomeCompleto(String nomeCompleto) {
+    this.nomeCompleto = nomeCompleto;
+  }
+
+  public String getDataNascimento() {
+    return dataNascimento;
+  }
+
+  public void setDataNascimento(String dataNascimento) {
+    this.dataNascimento = dataNascimento;
+  }
+
+  public String getProfissao() {
+    return profissao;
+  }
+
+  public void setProfissao(String profissao) {
+    this.profissao = profissao;
+  }
+
+  public String getParentesco() {
+    return parentesco;
+  }
+
+  public void setParentesco(String parentesco) {
+    this.parentesco = parentesco;
+  }
+
+  public boolean isResponsavelPrincipal() {
+    return responsavelPrincipal;
+  }
+
+  public void setResponsavelPrincipal(boolean responsavelPrincipal) {
+    this.responsavelPrincipal = responsavelPrincipal;
+  }
+
+  public String getProbabilidadeVoto() {
+    return probabilidadeVoto;
+  }
+
+  public void setProbabilidadeVoto(String probabilidadeVoto) {
+    this.probabilidadeVoto = probabilidadeVoto;
+  }
+
+  public String getTelefone() {
+    return telefone;
+  }
+
+  public void setTelefone(String telefone) {
+    this.telefone = telefone;
+  }
+
+  public OffsetDateTime getCriadoEm() {
+    return criadoEm;
+  }
+
+  public void setCriadoEm(OffsetDateTime criadoEm) {
+    this.criadoEm = criadoEm;
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/model/GrauParentesco.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/model/GrauParentesco.java
@@ -1,0 +1,35 @@
+package com.gestorpolitico.springbackend.model;
+
+public enum GrauParentesco {
+  PAI,
+  MAE,
+  FILHOA,
+  FILHA,
+  FILHO,
+  IRMAOA,
+  PRIMOA,
+  TIOA,
+  SOBRINHOA,
+  CONJUGE,
+  AVOO,
+  ENTEADOA,
+  OUTRO;
+
+  public String toDatabaseValue() {
+    return switch (this) {
+      case PAI -> "Pai";
+      case MAE -> "Mãe";
+      case FILHOA -> "Filho(a)";
+      case FILHA -> "Filha";
+      case FILHO -> "Filho";
+      case IRMAOA -> "Irmão(ã)";
+      case PRIMOA -> "Primo(a)";
+      case TIOA -> "Tio(a)";
+      case SOBRINHOA -> "Sobrinho(a)";
+      case CONJUGE -> "Cônjuge";
+      case AVOO -> "Avô(ó)";
+      case ENTEADOA -> "Enteado(a)";
+      case OUTRO -> "Outro";
+    };
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/model/Usuario.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/model/Usuario.java
@@ -1,0 +1,40 @@
+package com.gestorpolitico.springbackend.model;
+
+public class Usuario {
+  private Long id;
+  private String usuario;
+  private String senha;
+  private String nome;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getUsuario() {
+    return usuario;
+  }
+
+  public void setUsuario(String usuario) {
+    this.usuario = usuario;
+  }
+
+  public String getSenha() {
+    return senha;
+  }
+
+  public void setSenha(String senha) {
+    this.senha = senha;
+  }
+
+  public String getNome() {
+    return nome;
+  }
+
+  public void setNome(String nome) {
+    this.nome = nome;
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/repository/FamiliaRepository.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/repository/FamiliaRepository.java
@@ -1,0 +1,179 @@
+package com.gestorpolitico.springbackend.repository;
+
+import com.gestorpolitico.springbackend.dto.FamiliaRequest;
+import com.gestorpolitico.springbackend.dto.FamiliaResponse;
+import com.gestorpolitico.springbackend.dto.MembroFamiliaRequest;
+import com.gestorpolitico.springbackend.dto.MembroFamiliaResponse;
+import com.gestorpolitico.springbackend.model.GrauParentesco;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Repository
+public class FamiliaRepository {
+  private final JdbcTemplate jdbcTemplate;
+  private final TransactionTemplate transactionTemplate;
+
+  public FamiliaRepository(JdbcTemplate jdbcTemplate, PlatformTransactionManager txManager) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.transactionTemplate = new TransactionTemplate(txManager);
+  }
+
+  public FamiliaResponse salvarFamilia(FamiliaRequest request) {
+    return transactionTemplate.execute(status -> {
+      KeyHolder keyHolder = new GeneratedKeyHolder();
+      jdbcTemplate.update(con -> {
+        PreparedStatement ps = con.prepareStatement(
+          "INSERT INTO familia (endereco, bairro, telefone) VALUES (?, ?, ?)",
+          Statement.RETURN_GENERATED_KEYS
+        );
+        ps.setString(1, request.getEndereco());
+        ps.setString(2, request.getBairro());
+        ps.setString(3, request.getTelefone());
+        return ps;
+      }, keyHolder);
+
+      Number key = Optional.ofNullable(keyHolder.getKey())
+        .orElseThrow(() -> new IllegalStateException("Não foi possível obter o id da família."));
+      Long familiaId = key.longValue();
+
+      for (MembroFamiliaRequest membro : request.getMembros()) {
+        inserirMembro(familiaId, membro);
+      }
+
+      return buscarPorId(familiaId).orElseThrow(() ->
+        new IllegalStateException("Erro ao carregar família recém criada.")
+      );
+    });
+  }
+
+  public List<FamiliaResponse> listarFamilias() {
+    String sql =
+      "SELECT " +
+      "f.id AS f_id, f.endereco, f.bairro, f.telefone, f.criado_em AS f_criado_em, " +
+      "m.id AS m_id, m.nome_completo, m.data_nascimento, m.profissao, m.parentesco, " +
+      "m.responsavel_principal, m.probabilidade_voto, m.telefone AS m_telefone, m.criado_em AS m_criado_em " +
+      "FROM familia f " +
+      "LEFT JOIN membro_familia m ON m.familia_id = f.id " +
+      "ORDER BY f.criado_em DESC, m.criado_em ASC";
+
+    return jdbcTemplate.query(sql, rs -> {
+      Map<Long, FamiliaResponse> familias = new LinkedHashMap<>();
+      while (rs.next()) {
+        Long familiaId = rs.getLong("f_id");
+        FamiliaResponse familia = familias.computeIfAbsent(familiaId, id -> {
+          FamiliaResponse response = new FamiliaResponse();
+          response.setId(id);
+          response.setEndereco(rs.getString("endereco"));
+          response.setBairro(rs.getString("bairro"));
+          response.setTelefone(rs.getString("telefone"));
+          response.setCriadoEm(toOffsetDateTime(rs.getTimestamp("f_criado_em")));
+          response.setMembros(new ArrayList<>());
+          return response;
+        });
+
+        long membroId = rs.getLong("m_id");
+        if (!rs.wasNull()) {
+          familia.getMembros().add(mapearMembro(rs));
+        }
+      }
+      return new ArrayList<>(familias.values());
+    });
+  }
+
+  public Optional<FamiliaResponse> buscarPorId(Long id) {
+    String sql =
+      "SELECT " +
+      "f.id AS f_id, f.endereco, f.bairro, f.telefone, f.criado_em AS f_criado_em, " +
+      "m.id AS m_id, m.nome_completo, m.data_nascimento, m.profissao, m.parentesco, " +
+      "m.responsavel_principal, m.probabilidade_voto, m.telefone AS m_telefone, m.criado_em AS m_criado_em " +
+      "FROM familia f " +
+      "LEFT JOIN membro_familia m ON m.familia_id = f.id " +
+      "WHERE f.id = ? " +
+      "ORDER BY m.criado_em ASC";
+
+    List<FamiliaResponse> familias = jdbcTemplate.query(sql, ps -> ps.setLong(1, id), rs -> {
+      Map<Long, FamiliaResponse> mapa = new LinkedHashMap<>();
+      while (rs.next()) {
+        Long familiaId = rs.getLong("f_id");
+        FamiliaResponse familia = mapa.computeIfAbsent(familiaId, fid -> {
+          FamiliaResponse response = new FamiliaResponse();
+          response.setId(fid);
+          response.setEndereco(rs.getString("endereco"));
+          response.setBairro(rs.getString("bairro"));
+          response.setTelefone(rs.getString("telefone"));
+          response.setCriadoEm(toOffsetDateTime(rs.getTimestamp("f_criado_em")));
+          response.setMembros(new ArrayList<>());
+          return response;
+        });
+
+        long membroId = rs.getLong("m_id");
+        if (!rs.wasNull()) {
+          familia.getMembros().add(mapearMembro(rs));
+        }
+      }
+      return new ArrayList<>(mapa.values());
+    });
+    return familias.stream().findFirst();
+  }
+
+  private void inserirMembro(Long familiaId, MembroFamiliaRequest membro) {
+    jdbcTemplate.update(con -> {
+      PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO membro_familia (familia_id, nome_completo, data_nascimento, profissao, parentesco, responsavel_principal, probabilidade_voto, telefone) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+      );
+      ps.setLong(1, familiaId);
+      ps.setString(2, membro.getNomeCompleto());
+      if (membro.getDataNascimento() != null && !membro.getDataNascimento().isBlank()) {
+        LocalDate data = LocalDate.parse(membro.getDataNascimento());
+        ps.setDate(3, Date.valueOf(data));
+      } else {
+        ps.setNull(3, java.sql.Types.DATE);
+      }
+      ps.setString(4, membro.getProfissao());
+      ps.setString(5, membro.getParentesco().toDatabaseValue());
+      ps.setBoolean(6, Boolean.TRUE.equals(membro.getResponsavelPrincipal()));
+      ps.setString(7, membro.getProbabilidadeVoto());
+      ps.setString(8, membro.getTelefone());
+      return ps;
+    });
+  }
+
+  private MembroFamiliaResponse mapearMembro(java.sql.ResultSet rs) throws java.sql.SQLException {
+    MembroFamiliaResponse membro = new MembroFamiliaResponse();
+    membro.setId(rs.getLong("m_id"));
+    membro.setNomeCompleto(rs.getString("nome_completo"));
+    Date dataNascimento = rs.getDate("data_nascimento");
+    membro.setDataNascimento(dataNascimento != null ? dataNascimento.toLocalDate().toString() : null);
+    membro.setProfissao(rs.getString("profissao"));
+    membro.setParentesco(rs.getString("parentesco"));
+    membro.setResponsavelPrincipal(rs.getBoolean("responsavel_principal"));
+    membro.setProbabilidadeVoto(rs.getString("probabilidade_voto"));
+    membro.setTelefone(rs.getString("m_telefone"));
+    membro.setCriadoEm(toOffsetDateTime(rs.getTimestamp("m_criado_em")));
+    return membro;
+  }
+
+  private OffsetDateTime toOffsetDateTime(Timestamp timestamp) {
+    if (timestamp == null) {
+      return null;
+    }
+    return timestamp.toInstant().atOffset(ZoneOffset.UTC);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/repository/LoginRepository.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/repository/LoginRepository.java
@@ -1,0 +1,33 @@
+package com.gestorpolitico.springbackend.repository;
+
+import com.gestorpolitico.springbackend.model.Usuario;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LoginRepository {
+  private final JdbcTemplate jdbcTemplate;
+  private final RowMapper<Usuario> usuarioMapper = (rs, rowNum) -> {
+    Usuario usuario = new Usuario();
+    usuario.setId(rs.getLong("id"));
+    usuario.setUsuario(rs.getString("usuario"));
+    usuario.setSenha(rs.getString("senha"));
+    usuario.setNome(rs.getString("nome"));
+    return usuario;
+  };
+
+  public LoginRepository(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public Optional<Usuario> buscarPorCredenciais(String usuario, String senha) {
+    return jdbcTemplate.query(
+      "SELECT id, usuario, senha, nome FROM login WHERE usuario = ? AND senha = ?",
+      usuarioMapper,
+      usuario,
+      senha
+    ).stream().findFirst();
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/security/BearerlessAuthenticationFilter.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/security/BearerlessAuthenticationFilter.java
@@ -1,0 +1,82 @@
+package com.gestorpolitico.springbackend.security;
+
+import com.gestorpolitico.springbackend.model.Usuario;
+import com.gestorpolitico.springbackend.service.LoginService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class BearerlessAuthenticationFilter extends OncePerRequestFilter {
+  private final LoginService loginService;
+
+  public BearerlessAuthenticationFilter(LoginService loginService) {
+    this.loginService = loginService;
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return "/api/login".equals(path) || !path.startsWith("/api");
+  }
+
+  @Override
+  protected void doFilterInternal(
+    HttpServletRequest request,
+    HttpServletResponse response,
+    FilterChain filterChain
+  ) throws ServletException, IOException {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (header == null || !header.startsWith("Basic ")) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Credenciais ausentes.");
+      return;
+    }
+
+    Optional<Usuario> autenticado = extrairCredenciais(header)
+      .flatMap(credenciais -> loginService.autenticarUsuario(credenciais.usuario(), credenciais.senha()));
+
+    if (autenticado.isEmpty()) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Credenciais inválidas.");
+      return;
+    }
+
+    Usuario usuario = autenticado.get();
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+      usuario,
+      null,
+      List.of()
+    );
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+    filterChain.doFilter(request, response);
+  }
+
+  private Optional<Credenciais> extrairCredenciais(String header) {
+    try {
+      String base64 = header.substring("Basic ".length());
+      byte[] decoded = Base64.getDecoder().decode(base64);
+      String token = new String(decoded, StandardCharsets.UTF_8);
+      int idx = token.indexOf(':');
+      if (idx <= 0) {
+        return Optional.empty();
+      }
+      String usuario = token.substring(0, idx);
+      String senha = token.substring(idx + 1);
+      return Optional.of(new Credenciais(usuario, senha));
+    } catch (IllegalArgumentException ex) {
+      return Optional.empty();
+    }
+  }
+
+  private record Credenciais(String usuario, String senha) {}
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/service/FamiliaService.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/service/FamiliaService.java
@@ -1,0 +1,24 @@
+package com.gestorpolitico.springbackend.service;
+
+import com.gestorpolitico.springbackend.dto.FamiliaRequest;
+import com.gestorpolitico.springbackend.dto.FamiliaResponse;
+import com.gestorpolitico.springbackend.repository.FamiliaRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FamiliaService {
+  private final FamiliaRepository familiaRepository;
+
+  public FamiliaService(FamiliaRepository familiaRepository) {
+    this.familiaRepository = familiaRepository;
+  }
+
+  public List<FamiliaResponse> listarFamilias() {
+    return familiaRepository.listarFamilias();
+  }
+
+  public FamiliaResponse criarFamilia(FamiliaRequest request) {
+    return familiaRepository.salvarFamilia(request);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/service/LoginService.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/service/LoginService.java
@@ -1,0 +1,30 @@
+package com.gestorpolitico.springbackend.service;
+
+import com.gestorpolitico.springbackend.dto.LoginResponse;
+import com.gestorpolitico.springbackend.dto.LoginResponse.UsuarioDto;
+import com.gestorpolitico.springbackend.model.Usuario;
+import com.gestorpolitico.springbackend.repository.LoginRepository;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoginService {
+  private final LoginRepository loginRepository;
+
+  public LoginService(LoginRepository loginRepository) {
+    this.loginRepository = loginRepository;
+  }
+
+  public Optional<LoginResponse> autenticar(String usuario, String senha) {
+    return autenticarUsuario(usuario, senha).map(this::mapearParaResposta);
+  }
+
+  public Optional<Usuario> autenticarUsuario(String usuario, String senha) {
+    return loginRepository.buscarPorCredenciais(usuario, senha);
+  }
+
+  private LoginResponse mapearParaResposta(Usuario usuario) {
+    UsuarioDto dto = new UsuarioDto(usuario.getId(), usuario.getUsuario(), usuario.getNome());
+    return new LoginResponse(true, null, dto);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/springbackend/validation/ApiExceptionHandler.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/springbackend/validation/ApiExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.gestorpolitico.springbackend.validation;
+
+import com.gestorpolitico.springbackend.dto.ErrorResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidacao(MethodArgumentNotValidException ex) {
+    List<String> erros = ex
+      .getBindingResult()
+      .getFieldErrors()
+      .stream()
+      .map(this::formatarErro)
+      .toList();
+    ErrorResponse body = new ErrorResponse(false, "Dados inválidos.", erros);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponse> handleConstraint(ConstraintViolationException ex) {
+    List<String> erros = ex
+      .getConstraintViolations()
+      .stream()
+      .map(violation -> violation.getMessage())
+      .collect(Collectors.toList());
+    ErrorResponse body = new ErrorResponse(false, "Dados inválidos.", erros);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalState(IllegalStateException ex) {
+    ErrorResponse body = new ErrorResponse(false, ex.getMessage(), List.of());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGenerico(Exception ex) {
+    ErrorResponse body = new ErrorResponse(false, "Erro no servidor.", List.of(ex.getMessage()));
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+  }
+
+  private String formatarErro(FieldError fieldError) {
+    return "%s: %s".formatted(fieldError.getField(), fieldError.getDefaultMessage());
+  }
+}

--- a/spring-backend/src/main/resources/application.properties
+++ b/spring-backend/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/gestor_politico
+spring.datasource.username=postgres
+spring.datasource.password=admin
+spring.datasource.hikari.maximum-pool-size=5
+spring.main.web-application-type=servlet
+logging.level.org.springframework.security=INFO


### PR DESCRIPTION
## Sumário
- converte as validações do cadastro de famílias para Bean Validation com DTOs aninhados
- adiciona tratamento padronizado de erros de validação e regras de negócio
- cria filtro de autenticação Basic com Spring Security e configurações stateless para os endpoints
- implementa repositórios JDBC e serviços para login e famílias, espelhando a lógica do Express

## Testes
- npm test (backend)
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d01de272a08328ac2a92a845788ea5