### PR TITLE
Implementa tratamento global de erros no Spring Boot

### DIFF
--- a/spring-backend/README.md
+++ b/spring-backend/README.md
@@ -1,0 +1,21 @@
+# Tratamento Global de Erros no Spring Boot
+
+Este módulo demonstra como migrar o tratamento de erros do backend Express para um `@ControllerAdvice` global no Spring Boot.
+
+## Como funciona
+
+- **`BusinessException`** representa erros de regra de negócio que no Express eram retornados com `res.status(400|422)`.
+- **`ValidationException`** encapsula problemas de validação explícita (equivalente aos `return res.status(400)` do Express).
+- **`MethodArgumentNotValidException`** cobre validações do Bean Validation anotadas diretamente nos DTOs.
+- **`RuntimeException`** captura falhas inesperadas que no Express resultavam em `res.status(500)` ou em `next(err)`.
+
+Todas as respostas seguem o mesmo padrão JSON:
+
+```json
+{
+  "code": "IDENTIFICADOR_DO_ERRO",
+  "message": "Descrição legível do problema"
+}
+```
+
+Erros de validação incluem um objeto `errors` com os detalhes campo a campo.

--- a/spring-backend/src/main/java/com/gestorpolitico/api/exception/ApiErrorResponse.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/api/exception/ApiErrorResponse.java
@@ -1,0 +1,4 @@
+package com.gestorpolitico.api.exception;
+
+public record ApiErrorResponse(String code, String message) {
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/api/exception/BusinessException.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/api/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.gestorpolitico.api.exception;
+
+public class BusinessException extends RuntimeException {
+  private final String code;
+
+  public BusinessException(String code, String message) {
+    super(message);
+    this.code = code;
+  }
+
+  public String getCode() {
+    return code;
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/api/exception/GlobalExceptionHandler.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.gestorpolitico.api.exception;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ApiErrorResponse> handleBusinessException(BusinessException ex) {
+    ApiErrorResponse response = new ApiErrorResponse(ex.getCode(), ex.getMessage());
+    return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(response);
+  }
+
+  @ExceptionHandler(ValidationException.class)
+  public ResponseEntity<Map<String, Object>> handleValidationException(ValidationException ex) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("code", "VALIDATION_ERROR");
+    body.put("message", ex.getMessage());
+    body.put("errors", ex.getErrors());
+    return ResponseEntity.badRequest().body(body);
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public Map<String, Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("code", "VALIDATION_ERROR");
+    body.put("message", "Erros de validação encontrados");
+    Map<String, String> fieldErrors = new HashMap<>();
+    for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+      fieldErrors.put(error.getField(), error.getDefaultMessage());
+    }
+    body.put("errors", fieldErrors);
+    body.put("timestamp", LocalDateTime.now());
+    return body;
+  }
+
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<ApiErrorResponse> handleRuntimeException(RuntimeException ex) {
+    ApiErrorResponse response = new ApiErrorResponse("INTERNAL_ERROR", "Ocorreu um erro inesperado");
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+  }
+}

--- a/spring-backend/src/main/java/com/gestorpolitico/api/exception/ValidationException.java
+++ b/spring-backend/src/main/java/com/gestorpolitico/api/exception/ValidationException.java
@@ -1,0 +1,16 @@
+package com.gestorpolitico.api.exception;
+
+import java.util.List;
+
+public class ValidationException extends RuntimeException {
+  private final List<String> errors;
+
+  public ValidationException(List<String> errors) {
+    super("Dados inválidos");
+    this.errors = errors;
+  }
+
+  public List<String> getErrors() {
+    return errors;
+  }
+}


### PR DESCRIPTION
## Resumo
- adiciona módulo ilustrativo com tratamento global de exceções usando @ControllerAdvice
- cria classes de exceção de negócio e validação com respostas JSON padronizadas
- documenta como o handler substitui o fluxo de erro anterior do Express

## Testes
- npm test (backend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d01de7eaf8832884cbc5a082edf7af