### PR TITLE
Ajusta uso de Collectors na FamiliaService

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/service/FamiliaService.java
+++ b/backend-java/src/main/java/com/gestorpolitico/service/FamiliaService.java
@@ -41,7 +41,9 @@ public class FamiliaService {
     familia.setBairro(dto.getBairro());
     familia.setTelefone(dto.getTelefone());
 
-    List<MembroFamilia> membros = dto.getMembros().stream().map(this::converterMembro).toList();
+    List<MembroFamilia> membros = dto.getMembros().stream()
+      .map(this::converterMembro)
+      .collect(Collectors.toList());
     membros.forEach(familia::adicionarMembro);
 
     Familia salvo = familiaRepository.save(familia);


### PR DESCRIPTION
## Summary
- substitui o uso de toList() por Collectors.toList() na criação da lista de membros da família

## Testing
- ⚠️ `mvn -f backend-java/pom.xml clean verify` *(falha devido à indisponibilidade para baixar dependências do Spring Boot)*

------
https://chatgpt.com/codex/tasks/task_e_68d0877173d88328b920b3e7032f6d6a