### PR TITLE
Corrige base das URLs de API no frontend

### DIFF
--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { buildApiUrl } from '../shared/api-url.util';
 
 export interface FamiliaMembroPayload {
   nomeCompleto: string;
@@ -42,7 +43,7 @@ export interface FamiliaResponse {
 
 @Injectable({ providedIn: 'root' })
 export class FamiliasService {
-  private readonly apiUrl = 'http://localhost:8080/api/familias';
+  private readonly apiUrl = buildApiUrl('familias');
 
   constructor(private readonly http: HttpClient) {}
 

--- a/frontend/src/app/modules/login/login.component.ts
+++ b/frontend/src/app/modules/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { buildApiUrl } from '../shared/api-url.util';
 
 interface LoginResponse {
   id: number;
@@ -62,7 +63,7 @@ export class LoginComponent {
     this.isLoading = true;
 
     this.http
-      .post<LoginResponse>('http://localhost:8080/api/login', {
+      .post<LoginResponse>(buildApiUrl('login'), {
         usuario: trimmedUsername,
         senha: trimmedPassword
       })

--- a/frontend/src/app/modules/shared/api-url.util.ts
+++ b/frontend/src/app/modules/shared/api-url.util.ts
@@ -1,0 +1,29 @@
+const DEV_API_URL = 'http://localhost:8080/api';
+const DEV_SERVER_PORT = '4200';
+
+let cachedBaseUrl: string | null = null;
+
+function resolveBaseUrl(): string {
+  if (cachedBaseUrl) {
+    return cachedBaseUrl;
+  }
+
+  if (typeof window === 'undefined') {
+    cachedBaseUrl = DEV_API_URL;
+    return cachedBaseUrl;
+  }
+
+  const { hostname, port, origin } = window.location;
+  if ((hostname === 'localhost' || hostname === '127.0.0.1') && port === DEV_SERVER_PORT) {
+    cachedBaseUrl = DEV_API_URL;
+    return cachedBaseUrl;
+  }
+
+  cachedBaseUrl = `${origin}/api`;
+  return cachedBaseUrl;
+}
+
+export function buildApiUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${resolveBaseUrl()}${normalizedPath}`;
+}


### PR DESCRIPTION
## Resumo
- cria utilitário compartilhado para montar URLs da API de forma dinâmica
- atualiza login e serviço de famílias para usar a base calculada conforme ambiente

## Testes
- npm test (frontend)
- npm test (backend) *(falha: ausência de package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d088a728808328b57805dd38a058f9