### PR TITLE
Add WebClient dependencies and Java 17 compiler config

### DIFF
--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -9,6 +9,8 @@
   <packaging>jar</packaging>
   <properties>
     <java.version>17</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <spring.boot.version>3.2.5</spring.boot.version>
   </properties>
   <dependencyManagement>
@@ -26,6 +28,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- inclui o starter do Spring WebFlux para disponibilizar o WebClient
- define a versão do compilador Maven para Java 17 garantindo suporte a records

## Testing
- mvn -B test *(falhou: Network is unreachable ao baixar dependências do Spring Boot)*
- npm test (frontend)
- npm test (backend-java) *(falhou: package.json inexistente)*

------
https://chatgpt.com/codex/tasks/task_e_68d09bb80b8083288d0c85f99be954bb