### PR TITLE
Corrigir resolução de parâmetros em LocalidadeController

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/controller/LocalidadeController.java
+++ b/backend-java/src/main/java/com/gestorpolitico/controller/LocalidadeController.java
@@ -36,20 +36,22 @@ public class LocalidadeController {
 
   @GetMapping("/cidades/{cidadeId}/bairros")
   public ResponseEntity<List<BairroResponseDTO>> listarBairros(
-    @PathVariable Long cidadeId,
+    @PathVariable("cidadeId") Long cidadeId,
     @RequestParam(required = false) String regiao
   ) {
     return ResponseEntity.ok(localidadeService.listarBairros(cidadeId, regiao));
   }
 
   @GetMapping("/cidades/{cidadeId}/regioes")
-  public ResponseEntity<List<RegiaoResponseDTO>> listarRegioes(@PathVariable Long cidadeId) {
+  public ResponseEntity<List<RegiaoResponseDTO>> listarRegioes(
+    @PathVariable("cidadeId") Long cidadeId
+  ) {
     return ResponseEntity.ok(localidadeService.listarRegioes(cidadeId));
   }
 
   @PostMapping("/cidades/{cidadeId}/regioes")
   public ResponseEntity<RegiaoResponseDTO> criarRegiao(
-    @PathVariable Long cidadeId,
+    @PathVariable("cidadeId") Long cidadeId,
     @Valid @RequestBody RegiaoRequestDTO dto
   ) {
     return ResponseEntity.ok(localidadeService.criarRegiao(cidadeId, dto));
@@ -57,7 +59,7 @@ public class LocalidadeController {
 
   @PutMapping("/regioes/{regiaoId}/bairros")
   public ResponseEntity<Void> atribuirRegiao(
-    @PathVariable Long regiaoId,
+    @PathVariable("regiaoId") Long regiaoId,
     @Valid @RequestBody RegiaoAtribuicaoRequestDTO dto
   ) {
     localidadeService.atribuirRegiao(regiaoId, dto.getBairrosIds());
@@ -73,7 +75,9 @@ public class LocalidadeController {
   }
 
   @PostMapping("/cidades/{cidadeId}/importar-bairros")
-  public ResponseEntity<ImportacaoBairrosResponseDTO> importarBairros(@PathVariable Long cidadeId) {
+  public ResponseEntity<ImportacaoBairrosResponseDTO> importarBairros(
+    @PathVariable("cidadeId") Long cidadeId
+  ) {
     return ResponseEntity.ok(localidadeService.importarBairros(cidadeId));
   }
 }


### PR DESCRIPTION
## Resumo
- define explicitamente os nomes dos parâmetros em todos os `@PathVariable` do `LocalidadeController`
- garante que a importação de bairros não dependa da flag `-parameters` na compilação

## Testes
- npm test -- --watch=false
- mvn test *(falha: dependências não puderam ser baixadas por falta de acesso à internet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b3e1cd3c8328b033d6a70a1ac36e