### PR TITLE
Centraliza endereço por família

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaRequestDTO.java
@@ -3,17 +3,32 @@ package com.gestorpolitico.dto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public class FamiliaRequestDTO {
-  @NotBlank(message = "O endereço é obrigatório.")
-  @Size(max = 255, message = "O endereço deve ter no máximo 255 caracteres.")
-  private String endereco;
+  @Size(max = 9, message = "O CEP deve ter no máximo 9 caracteres.")
+  private String cep;
 
-  @NotBlank(message = "O bairro é obrigatório.")
-  @Size(max = 120, message = "O bairro deve ter no máximo 120 caracteres.")
-  private String bairro;
+  @NotBlank(message = "Informe a rua da família.")
+  @Size(max = 255, message = "A rua deve ter no máximo 255 caracteres.")
+  private String rua;
+
+  @NotBlank(message = "Informe o número do endereço da família.")
+  @Size(max = 30, message = "O número deve ter no máximo 30 caracteres.")
+  private String numero;
+
+  @NotNull(message = "Selecione a cidade da família.")
+  private Long cidadeId;
+
+  private Long bairroId;
+
+  @Size(max = 150, message = "O bairro deve ter no máximo 150 caracteres.")
+  private String novoBairro;
+
+  @Size(max = 120, message = "A região deve ter no máximo 120 caracteres.")
+  private String novaRegiao;
 
   @NotBlank(message = "O telefone é obrigatório.")
   @Size(max = 30, message = "O telefone deve ter no máximo 30 caracteres.")
@@ -26,20 +41,60 @@ public class FamiliaRequestDTO {
   public FamiliaRequestDTO() {
   }
 
-  public String getEndereco() {
-    return endereco;
+  public String getCep() {
+    return cep;
   }
 
-  public void setEndereco(String endereco) {
-    this.endereco = endereco;
+  public void setCep(String cep) {
+    this.cep = cep;
   }
 
-  public String getBairro() {
-    return bairro;
+  public String getRua() {
+    return rua;
   }
 
-  public void setBairro(String bairro) {
-    this.bairro = bairro;
+  public void setRua(String rua) {
+    this.rua = rua;
+  }
+
+  public String getNumero() {
+    return numero;
+  }
+
+  public void setNumero(String numero) {
+    this.numero = numero;
+  }
+
+  public Long getCidadeId() {
+    return cidadeId;
+  }
+
+  public void setCidadeId(Long cidadeId) {
+    this.cidadeId = cidadeId;
+  }
+
+  public Long getBairroId() {
+    return bairroId;
+  }
+
+  public void setBairroId(Long bairroId) {
+    this.bairroId = bairroId;
+  }
+
+  public String getNovoBairro() {
+    return novoBairro;
+  }
+
+  public void setNovoBairro(String novoBairro) {
+    this.novoBairro = novoBairro;
+  }
+
+  public String getNovaRegiao() {
+    return novaRegiao;
+  }
+
+  public void setNovaRegiao(String novaRegiao) {
+    this.novaRegiao = novaRegiao;
   }
 
   public String getTelefone() {

--- a/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaResponseDTO.java
@@ -10,6 +10,7 @@ public class FamiliaResponseDTO {
   private String bairro;
   private String telefone;
   private OffsetDateTime criadoEm;
+  private EnderecoResponseDTO enderecoDetalhado;
   private List<MembroFamiliaResponseDTO> membros = new ArrayList<>();
 
   public FamiliaResponseDTO() {
@@ -21,6 +22,7 @@ public class FamiliaResponseDTO {
     String bairro,
     String telefone,
     OffsetDateTime criadoEm,
+    EnderecoResponseDTO enderecoDetalhado,
     List<MembroFamiliaResponseDTO> membros
   ) {
     this.id = id;
@@ -28,6 +30,7 @@ public class FamiliaResponseDTO {
     this.bairro = bairro;
     this.telefone = telefone;
     this.criadoEm = criadoEm;
+    this.enderecoDetalhado = enderecoDetalhado;
     if (membros != null) {
       this.membros = membros;
     }
@@ -71,6 +74,14 @@ public class FamiliaResponseDTO {
 
   public void setCriadoEm(OffsetDateTime criadoEm) {
     this.criadoEm = criadoEm;
+  }
+
+  public EnderecoResponseDTO getEnderecoDetalhado() {
+    return enderecoDetalhado;
+  }
+
+  public void setEnderecoDetalhado(EnderecoResponseDTO enderecoDetalhado) {
+    this.enderecoDetalhado = enderecoDetalhado;
   }
 
   public List<MembroFamiliaResponseDTO> getMembros() {

--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
@@ -1,7 +1,6 @@
 package com.gestorpolitico.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -33,28 +32,6 @@ public class MembroFamiliaRequestDTO {
 
   @Size(max = 30, message = "O telefone deve ter no máximo 30 caracteres.")
   private String telefone;
-
-  @Size(max = 9, message = "O CEP deve ter no máximo 9 caracteres.")
-  private String cep;
-
-  @NotBlank(message = "Informe a rua do membro.")
-  @Size(max = 255, message = "A rua deve ter no máximo 255 caracteres.")
-  private String rua;
-
-  @NotBlank(message = "Informe o número do endereço.")
-  @Size(max = 30, message = "O número deve ter no máximo 30 caracteres.")
-  private String numero;
-
-  @NotNull(message = "Selecione a cidade do membro.")
-  private Long cidadeId;
-
-  private Long bairroId;
-
-  @Size(max = 150, message = "O bairro deve ter no máximo 150 caracteres.")
-  private String novoBairro;
-
-  @Size(max = 120, message = "A região deve ter no máximo 120 caracteres.")
-  private String novaRegiao;
 
   public MembroFamiliaRequestDTO() {
   }
@@ -123,59 +100,4 @@ public class MembroFamiliaRequestDTO {
     this.telefone = telefone;
   }
 
-  public String getCep() {
-    return cep;
-  }
-
-  public void setCep(String cep) {
-    this.cep = cep;
-  }
-
-  public String getRua() {
-    return rua;
-  }
-
-  public void setRua(String rua) {
-    this.rua = rua;
-  }
-
-  public String getNumero() {
-    return numero;
-  }
-
-  public void setNumero(String numero) {
-    this.numero = numero;
-  }
-
-  public Long getCidadeId() {
-    return cidadeId;
-  }
-
-  public void setCidadeId(Long cidadeId) {
-    this.cidadeId = cidadeId;
-  }
-
-  public Long getBairroId() {
-    return bairroId;
-  }
-
-  public void setBairroId(Long bairroId) {
-    this.bairroId = bairroId;
-  }
-
-  public String getNovoBairro() {
-    return novoBairro;
-  }
-
-  public void setNovoBairro(String novoBairro) {
-    this.novoBairro = novoBairro;
-  }
-
-  public String getNovaRegiao() {
-    return novaRegiao;
-  }
-
-  public void setNovaRegiao(String novaRegiao) {
-    this.novaRegiao = novaRegiao;
-  }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
@@ -13,8 +13,6 @@ public class MembroFamiliaResponseDTO {
   private boolean responsavelPrincipal;
   private String probabilidadeVoto;
   private String telefone;
-  private String cep;
-  private EnderecoResponseDTO endereco;
   private OffsetDateTime criadoEm;
 
   public MembroFamiliaResponseDTO() {
@@ -30,8 +28,6 @@ public class MembroFamiliaResponseDTO {
     boolean responsavelPrincipal,
     String probabilidadeVoto,
     String telefone,
-    String cep,
-    EnderecoResponseDTO endereco,
     OffsetDateTime criadoEm
   ) {
     this.id = id;
@@ -43,8 +39,6 @@ public class MembroFamiliaResponseDTO {
     this.responsavelPrincipal = responsavelPrincipal;
     this.probabilidadeVoto = probabilidadeVoto;
     this.telefone = telefone;
-    this.cep = cep;
-    this.endereco = endereco;
     this.criadoEm = criadoEm;
   }
 
@@ -118,22 +112,6 @@ public class MembroFamiliaResponseDTO {
 
   public void setTelefone(String telefone) {
     this.telefone = telefone;
-  }
-
-  public String getCep() {
-    return cep;
-  }
-
-  public void setCep(String cep) {
-    this.cep = cep;
-  }
-
-  public EnderecoResponseDTO getEndereco() {
-    return endereco;
-  }
-
-  public void setEndereco(EnderecoResponseDTO endereco) {
-    this.endereco = endereco;
   }
 
   public OffsetDateTime getCriadoEm() {

--- a/backend-java/src/main/java/com/gestorpolitico/entity/Familia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/Familia.java
@@ -7,7 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
@@ -40,6 +42,10 @@ public class Familia {
 
   @Column(name = "criado_em", nullable = false)
   private OffsetDateTime criadoEm = OffsetDateTime.now();
+
+  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "endereco_id", nullable = false)
+  private Endereco enderecoDetalhado;
 
   @OneToMany(mappedBy = "familia", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   private List<MembroFamilia> membros = new ArrayList<>();
@@ -82,6 +88,14 @@ public class Familia {
 
   public void setCriadoEm(OffsetDateTime criadoEm) {
     this.criadoEm = criadoEm;
+  }
+
+  public Endereco getEnderecoDetalhado() {
+    return enderecoDetalhado;
+  }
+
+  public void setEnderecoDetalhado(Endereco enderecoDetalhado) {
+    this.enderecoDetalhado = enderecoDetalhado;
   }
 
   public List<MembroFamilia> getMembros() {

--- a/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
@@ -1,6 +1,5 @@
 package com.gestorpolitico.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
@@ -60,11 +58,6 @@ public class MembroFamilia {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "familia_id", nullable = false)
   private Familia familia;
-
-  @NotNull
-  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-  @JoinColumn(name = "endereco_id", nullable = false)
-  private Endereco endereco;
 
   @Column(name = "criado_em", nullable = false)
   private OffsetDateTime criadoEm = OffsetDateTime.now();
@@ -147,14 +140,6 @@ public class MembroFamilia {
 
   public void setFamilia(Familia familia) {
     this.familia = familia;
-  }
-
-  public Endereco getEndereco() {
-    return endereco;
-  }
-
-  public void setEndereco(Endereco endereco) {
-    this.endereco = endereco;
   }
 
   public OffsetDateTime getCriadoEm() {

--- a/backend-java/src/main/resources/db/ddl.sql
+++ b/backend-java/src/main/resources/db/ddl.sql
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS familia (
   endereco VARCHAR(255) NOT NULL,
   bairro VARCHAR(120) NOT NULL,
   telefone VARCHAR(30) NOT NULL,
+  endereco_id BIGINT NOT NULL REFERENCES enderecos (id) ON DELETE CASCADE,
   criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
@@ -52,6 +53,5 @@ CREATE TABLE IF NOT EXISTS membro_familia (
   probabilidade_voto VARCHAR(255) NOT NULL,
   telefone VARCHAR(30),
   familia_id BIGINT NOT NULL REFERENCES familia (id) ON DELETE CASCADE,
-  endereco_id BIGINT NOT NULL REFERENCES enderecos (id) ON DELETE CASCADE,
   criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -12,6 +12,9 @@ export interface FamiliaMembroPayload {
   responsavelPrincipal: boolean;
   probabilidadeVoto: string;
   telefone: string | null;
+}
+
+export interface FamiliaPayload {
   cep: string | null;
   rua: string;
   numero: string;
@@ -19,16 +22,11 @@ export interface FamiliaMembroPayload {
   bairroId: number | null;
   novoBairro: string | null;
   novaRegiao: string | null;
-}
-
-export interface FamiliaPayload {
-  endereco: string;
-  bairro: string;
   telefone: string;
   membros: FamiliaMembroPayload[];
 }
 
-export interface EnderecoMembroResponse {
+export interface EnderecoFamiliaResponse {
   id: number;
   rua: string;
   numero: string;
@@ -51,8 +49,6 @@ export interface FamiliaMembroResponse {
   responsavelPrincipal: boolean;
   probabilidadeVoto: string;
   telefone: string | null;
-  cep: string | null;
-  endereco: EnderecoMembroResponse;
   criadoEm: string;
 }
 
@@ -62,6 +58,7 @@ export interface FamiliaResponse {
   bairro: string;
   telefone: string;
   criadoEm: string;
+  enderecoDetalhado: EnderecoFamiliaResponse;
   membros: FamiliaMembroResponse[];
 }
 

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -59,33 +59,21 @@
           <p class="text-xs text-gray-500 mt-2">O responsável é definido ao marcar a opção de responsável em um dos membros cadastrados.</p>
         </div>
 
-        <div class="md:col-span-2">
-          <label for="enderecoFamilia" class="block text-sm font-semibold text-gray-700 mb-2">Endereço Completo</label>
-          <input
-            id="enderecoFamilia"
-            type="text"
-            placeholder="Rua, número, bairro, cidade"
-            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-            [(ngModel)]="familia.endereco"
-            name="enderecoFamilia"
-          />
-        </div>
-
         <div>
-          <label for="bairroFamilia" class="block text-sm font-semibold text-gray-700 mb-2">Bairro</label>
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Cidade *</label>
           <select
-            id="bairroFamilia"
             class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-            [(ngModel)]="familia.bairro"
-            name="bairroFamilia"
+            [(ngModel)]="enderecoFamilia.cidadeId"
+            name="cidadeFamilia"
+            (ngModelChange)="aoAlterarCidadeFamilia($event)"
           >
-            <option value="">Selecione o bairro</option>
-            <option *ngFor="let bairro of bairrosDisponiveisFamilia" [value]="bairro">{{ bairro }}</option>
+            <option [ngValue]="null">Selecione a cidade</option>
+            <option *ngFor="let cidade of cidades" [ngValue]="cidade.id">{{ cidade.nome }} - {{ cidade.uf }}</option>
           </select>
         </div>
 
         <div>
-          <label for="telefoneFamilia" class="block text-sm font-semibold text-gray-700 mb-2">Telefone de Contato</label>
+          <label for="telefoneFamilia" class="block text-sm font-semibold text-gray-700 mb-2">Telefone de Contato *</label>
           <input
             id="telefoneFamilia"
             type="tel"
@@ -93,6 +81,109 @@
             class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
             [(ngModel)]="familia.telefone"
             name="telefoneFamilia"
+          />
+        </div>
+
+        <div class="md:col-span-2">
+          <label class="block text-sm font-semibold text-gray-700 mb-2">CEP</label>
+          <div class="flex flex-col space-y-2">
+            <div class="flex flex-col md:flex-row md:items-center md:space-x-3 space-y-2 md:space-y-0">
+              <input
+                type="text"
+                class="w-full md:flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+                [(ngModel)]="enderecoFamilia.cep"
+                name="cepFamilia"
+                placeholder="00000-000"
+              />
+              <div class="flex items-center space-x-2">
+                <button
+                  type="button"
+                  (click)="buscarCepFamilia()"
+                  [disabled]="enderecoFamilia.carregandoCep"
+                  class="px-4 py-2 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {{ enderecoFamilia.carregandoCep ? 'Buscando...' : 'Buscar CEP' }}
+                </button>
+                <button
+                  type="button"
+                  (click)="alternarPreenchimentoManualFamilia()"
+                  class="px-4 py-2 bg-gray-100 text-gray-700 rounded-xl font-medium hover:bg-gray-200 transition-colors"
+                >
+                  {{ enderecoFamilia.preenchimentoManual ? 'Usar CEP' : 'Preencher manualmente' }}
+                </button>
+              </div>
+            </div>
+            <p *ngIf="enderecoFamilia.erroCep" class="text-xs text-red-500">{{ enderecoFamilia.erroCep }}</p>
+          </div>
+        </div>
+
+        <div class="md:col-span-2">
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Rua *</label>
+          <input
+            type="text"
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [(ngModel)]="enderecoFamilia.rua"
+            name="ruaFamilia"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Número *</label>
+          <input
+            type="text"
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [(ngModel)]="enderecoFamilia.numero"
+            name="numeroFamilia"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Região</label>
+          <select
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [(ngModel)]="enderecoFamilia.regiaoSelecionada"
+            name="regiaoFamilia"
+            (ngModelChange)="aoAlterarRegiaoFamilia($event)"
+          >
+            <option [ngValue]="null">Selecione a região</option>
+            <option *ngFor="let regiao of enderecoFamilia.regioes" [ngValue]="regiao.nome">{{ regiao.nome }}</option>
+            <option [ngValue]="valorNovaRegiao">Cadastrar nova região</option>
+          </select>
+        </div>
+
+        <div *ngIf="enderecoFamilia.regiaoSelecionada === valorNovaRegiao">
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Nova Região *</label>
+          <input
+            type="text"
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [(ngModel)]="enderecoFamilia.novaRegiao"
+            name="novaRegiaoFamilia"
+            placeholder="Informe o nome da nova região"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Bairro *</label>
+          <select
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [(ngModel)]="enderecoFamilia.bairroSelecionado"
+            name="bairroFamilia"
+            (ngModelChange)="aoAlterarBairroFamilia($event)"
+          >
+            <option value="">Selecione o bairro</option>
+            <option *ngFor="let bairro of enderecoFamilia.bairros" [value]="bairro.id">{{ bairro.nome }}</option>
+            <option [value]="valorNovoBairro">Cadastrar novo bairro</option>
+          </select>
+        </div>
+
+        <div *ngIf="enderecoFamilia.bairroSelecionado === valorNovoBairro">
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Novo Bairro *</label>
+          <input
+            type="text"
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [(ngModel)]="enderecoFamilia.novoBairro"
+            name="novoBairroFamilia"
+            placeholder="Informe o nome do novo bairro"
           />
         </div>
       </div>
@@ -253,116 +344,8 @@
               </div>
             </div>
 
-            <div class="md:col-span-2">
-              <label class="block text-sm font-semibold text-gray-700 mb-2">CEP</label>
-              <div class="flex flex-col space-y-2">
-                <div class="flex flex-col md:flex-row md:items-center md:space-x-3 space-y-2 md:space-y-0">
-                  <input
-                    type="text"
-                    class="w-full md:flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                    [(ngModel)]="membro.cep"
-                    name="cep_{{ i }}"
-                    placeholder="00000-000"
-                  />
-                  <div class="flex items-center space-x-2">
-                    <button
-                      type="button"
-                      (click)="buscarCep(i)"
-                      [disabled]="membro.carregandoCep"
-                      class="px-4 py-2 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    >
-                      {{ membro.carregandoCep ? 'Buscando...' : 'Buscar CEP' }}
-                    </button>
-                    <button
-                      type="button"
-                      (click)="alternarPreenchimentoManual(i)"
-                      class="px-4 py-2 bg-gray-100 text-gray-700 rounded-xl font-medium hover:bg-gray-200 transition-colors"
-                    >
-                      {{ membro.preenchimentoManual ? 'Usar CEP' : 'Preencher manualmente' }}
-                    </button>
-                  </div>
-                </div>
-                <p *ngIf="membro.erroCep" class="text-xs text-red-500">{{ membro.erroCep }}</p>
-              </div>
-            </div>
+                        <!-- Campos de endereço removidos dos membros -->
 
-            <div class="md:col-span-2">
-              <label class="block text-sm font-semibold text-gray-700 mb-2">Rua *</label>
-              <input
-                type="text"
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [(ngModel)]="membro.rua"
-                name="rua_{{ i }}"
-              />
-            </div>
-
-            <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">Número *</label>
-              <input
-                type="text"
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [(ngModel)]="membro.numero"
-                name="numero_{{ i }}"
-              />
-            </div>
-
-            <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">Cidade *</label>
-              <select
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [(ngModel)]="membro.cidadeId"
-                name="cidade_{{ i }}"
-                (ngModelChange)="aoAlterarCidade(i, $event)"
-              >
-                <option [ngValue]="null">Selecione a cidade</option>
-                <option *ngFor="let cidade of cidades" [ngValue]="cidade.id">{{ cidade.nome }} - {{ cidade.uf }}</option>
-              </select>
-            </div>
-
-            <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">Região</label>
-              <select
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [(ngModel)]="membro.regiaoSelecionada"
-                name="regiao_{{ i }}"
-                (ngModelChange)="aoAlterarRegiao(i, $event)"
-              >
-                <option [ngValue]="null">Todas as regiões</option>
-                <option *ngFor="let regiao of membro.regioes" [ngValue]="regiao.nome">{{ regiao.nome }}</option>
-                <option [ngValue]="valorNovaRegiao">Cadastrar nova região</option>
-              </select>
-              <input
-                *ngIf="membro.regiaoSelecionada === valorNovaRegiao"
-                type="text"
-                class="mt-2 w-full px-4 py-3 border-2 border-blue-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                placeholder="Nome da nova região"
-                [(ngModel)]="membro.novaRegiao"
-                name="novaRegiao_{{ i }}"
-              />
-            </div>
-
-            <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">Bairro *</label>
-              <select
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [(ngModel)]="membro.bairroSelecionado"
-                name="bairro_{{ i }}"
-                (ngModelChange)="aoAlterarBairro(i, $event)"
-              >
-                <option [ngValue]="null">Selecione o bairro</option>
-                <option *ngFor="let bairro of membro.bairros" [ngValue]="bairro.id.toString()">{{ bairro.nome }}</option>
-                <option [ngValue]="valorNovoBairro">Cadastrar novo bairro</option>
-              </select>
-              <input
-                *ngIf="membro.bairroSelecionado === valorNovoBairro"
-                type="text"
-                class="mt-2 w-full px-4 py-3 border-2 border-blue-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                placeholder="Nome do novo bairro"
-                [(ngModel)]="membro.novoBairro"
-                name="novoBairro_{{ i }}"
-              />
-            </div>
-          </div>
         </div>
       </div>
 
@@ -426,19 +409,25 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.828 0l-4.243-4.243a8 8 0 1111.314 0z"></path>
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
             </svg>
-            {{ previaFamilia.endereco }}
+            {{ previaFamilia.enderecoCompleto }}
+          </div>
+          <div class="flex items-center text-gray-600">
+            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z"></path>
+            </svg>
+            {{ previaFamilia.bairro }}<span *ngIf="previaFamilia.regiao"> • {{ previaFamilia.regiao }}</span>
+          </div>
+          <div class="flex items-center text-gray-600">
+            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z"></path>
+            </svg>
+            {{ previaFamilia.cidade }}<span *ngIf="previaFamilia.cep"> • CEP {{ previaFamilia.cep }}</span>
           </div>
           <div class="flex items-center text-gray-600">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
             </svg>
-            {{ previaFamilia.telefone }}
-          </div>
-          <div class="flex items-center text-gray-600">
-            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
-            </svg>
-            {{ previaFamilia.bairro }}
+            {{ previaFamilia.telefone || 'Telefone não informado' }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Resumo
- move o endereço detalhado para a entidade de família e remove vínculo individual em membros
- ajusta DTOs, serviço e DDL para tratar CEP, cidade, bairro e geolocalização por família
- atualiza formulário Angular para capturar endereço único por família e ajustar payload/previsão

## Testes
- npm test -- --watch=false
- mvn test *(falha: dependências do Spring Boot não resolvidas por falta de rede)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b1a3958c8328b2b6e21c5a9b1726