### PR TITLE
Restringe criação manual de bairros e regiões

### DIFF
--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -147,11 +147,13 @@
           >
             <option [ngValue]="null">Selecione a região</option>
             <option *ngFor="let regiao of enderecoFamilia.regioes" [ngValue]="regiao.nome">{{ regiao.nome }}</option>
-            <option [ngValue]="valorNovaRegiao">Cadastrar nova região</option>
+            <option *ngIf="ehAdministrador || novaRegiaoGeradaPorCep" [ngValue]="valorNovaRegiao">
+              Cadastrar nova região
+            </option>
           </select>
         </div>
 
-        <div *ngIf="enderecoFamilia.regiaoSelecionada === valorNovaRegiao">
+        <div *ngIf="enderecoFamilia.regiaoSelecionada === valorNovaRegiao && (ehAdministrador || novaRegiaoGeradaPorCep)">
           <label class="block text-sm font-semibold text-gray-700 mb-2">Nova Região *</label>
           <input
             type="text"
@@ -172,11 +174,13 @@
           >
             <option value="">Selecione o bairro</option>
             <option *ngFor="let bairro of enderecoFamilia.bairros" [value]="bairro.id">{{ bairro.nome }}</option>
-            <option [value]="valorNovoBairro">Cadastrar novo bairro</option>
+            <option *ngIf="ehAdministrador || novoBairroGeradoPorCep" [value]="valorNovoBairro">
+              Cadastrar novo bairro
+            </option>
           </select>
         </div>
 
-        <div *ngIf="enderecoFamilia.bairroSelecionado === valorNovoBairro">
+        <div *ngIf="enderecoFamilia.bairroSelecionado === valorNovoBairro && (ehAdministrador || novoBairroGeradoPorCep)">
           <label class="block text-sm font-semibold text-gray-700 mb-2">Novo Bairro *</label>
           <input
             type="text"


### PR DESCRIPTION
## Resumo
- impede usuários sem perfil de administrador de selecionar a criação manual de bairros e regiões
- exibe os campos de novo bairro/região apenas quando o CEP preencher automaticamente ou quando o usuário for administrador

## Testes
- npm test -- --watch=false (frontend)
- npm test (backend-java) *(falha: diretório sem package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d183bd160083289e0045c8ad168a9a