### PR TITLE
Ajusta perfil e menu admin

### DIFF
--- a/frontend/src/app/components/top-nav/top-nav.component.ts
+++ b/frontend/src/app/components/top-nav/top-nav.component.ts
@@ -85,8 +85,8 @@ export class TopNavComponent implements OnDestroy {
 
     if (usuario?.perfil === 'ADMINISTRADOR') {
       itensBase.push({
-        label: 'Configurações',
-        description: 'Importar bairros e regiões',
+        label: 'Configurações de região',
+        description: 'Importar bairros e definir regiões',
         icon: 'M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 4.34l1.63 1.27a.5.5 0 01-.03.79l-1.94 1.12c-.14.77-',
         route: '/configuracoes'
       });

--- a/frontend/src/app/modules/perfil/perfil.component.html
+++ b/frontend/src/app/modules/perfil/perfil.component.html
@@ -6,6 +6,13 @@
     </div>
 
     <div class="px-8 py-6 space-y-6" *ngIf="!carregando; else carregandoTemplate">
+      <div class="flex flex-wrap items-center gap-3" *ngIf="perfilUsuario">
+        <span class="px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold">
+          {{ perfilUsuario === 'ADMINISTRADOR' ? 'Administrador' : 'Usuário' }}
+        </span>
+        <span class="text-xs text-gray-500">Perfil de acesso definido pelo administrador.</span>
+      </div>
+
       <div *ngIf="mensagemSucesso" class="p-3 rounded-2xl bg-green-50 text-green-700 text-sm">
         {{ mensagemSucesso }}
       </div>

--- a/frontend/src/app/modules/perfil/perfil.component.ts
+++ b/frontend/src/app/modules/perfil/perfil.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { finalize } from 'rxjs';
-import { AuthService } from '../shared/services/auth.service';
+import { AuthService, PerfilUsuario } from '../shared/services/auth.service';
 import { UsuariosService } from '../shared/services/usuarios.service';
 
 @Component({
@@ -16,6 +16,7 @@ export class PerfilComponent implements OnInit {
   salvando = false;
   mensagemSucesso = '';
   mensagemErro = '';
+  perfilUsuario: PerfilUsuario | null = null;
 
   formulario = this.fb.group({
     nome: ['', [Validators.required, Validators.minLength(3)]],
@@ -36,12 +37,14 @@ export class PerfilComponent implements OnInit {
       return;
     }
 
+    this.perfilUsuario = usuario.perfil;
     this.usuariosService.buscarPorId(usuario.id).subscribe({
       next: dados => {
         this.formulario.patchValue({
           nome: dados.nome,
           usuario: dados.usuario
         });
+        this.perfilUsuario = dados.perfil;
         this.carregando = false;
       },
         error: (erro: HttpErrorResponse) => {
@@ -84,6 +87,7 @@ export class PerfilComponent implements OnInit {
         next: usuarioAtualizado => {
           this.formulario.patchValue({ senha: '' });
           this.mensagemSucesso = 'Dados atualizados com sucesso!';
+          this.perfilUsuario = usuarioAtualizado.perfil ?? this.perfilUsuario;
           this.authService.atualizarUsuarioLocal({
             nome: usuarioAtualizado.nome,
             usuario: usuarioAtualizado.usuario


### PR DESCRIPTION
## Resumo
- exibe o perfil de acesso do usuário na tela de configurações sem permitir edição
- mantém o perfil sincronizado após atualização dos dados pessoais
- renomeia o item administrativo do menu superior para "Configurações de região"

## Testes
- npm test -- --watch=false (frontend)
- npm test -- --watch=false (backend-java) *(falha: ausência de package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d187c9480483288cd472f693b0896d