### PR TITLE
Corrige importação de bairros com UF no nome da cidade

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/service/IbgeService.java
+++ b/backend-java/src/main/java/com/gestorpolitico/service/IbgeService.java
@@ -81,7 +81,7 @@ public class IbgeService {
       return false;
     }
     String nomeMunicipio = normalizar(municipio.nome());
-    String nomeCidade = normalizar(cidade.getNome());
+    String nomeCidade = removerSufixoUf(normalizar(cidade.getNome()), cidade.getUf());
     return nomeMunicipio.equals(nomeCidade);
   }
 
@@ -95,6 +95,20 @@ public class IbgeService {
       .toUpperCase(Locale.ROOT)
       .replaceAll("\\s+", " ")
       .trim();
+  }
+
+  private String removerSufixoUf(String nomeCidade, String uf) {
+    if (nomeCidade == null || nomeCidade.isBlank()) {
+      return "";
+    }
+    if (uf == null || uf.isBlank()) {
+      return nomeCidade;
+    }
+    String sufixoUf = " " + uf.toUpperCase(Locale.ROOT).trim();
+    if (nomeCidade.endsWith(sufixoUf)) {
+      return nomeCidade.substring(0, nomeCidade.length() - sufixoUf.length()).trim();
+    }
+    return nomeCidade;
   }
 
   private <T> Optional<T> executarRequisicao(Mono<T> requisicao, String mensagemErro) {


### PR DESCRIPTION
## Resumo
- ajusta a validação do município retornado pelo IBGE para desconsiderar o sufixo de UF no nome cadastrado localmente
- evita que cidades com o estado anexado ao nome deixem de importar distritos/bairros

## Testes
- npm test (backend) *(falha: package.json ausente)*
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d1e5cd63e8832891c8692f98d13298