### PR TITLE
Ajusta formulário de família e contatos de responsáveis

### DIFF
--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -134,8 +134,8 @@
                 </div>
               </div>
               <div class="text-sm text-gray-500 text-right">
-                <div class="font-semibold text-gray-700">Contato</div>
-                <div>{{ familia.telefone || 'Telefone não informado' }}</div>
+                <div class="font-semibold text-gray-700">Contato do responsável</div>
+                <div>{{ obterTelefoneResponsavel(familia) }}</div>
               </div>
             </div>
           </div>

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -40,6 +40,14 @@ export class FamiliasComponent implements OnInit {
     return responsavel?.nomeCompleto || 'Responsável não informado';
   }
 
+  obterTelefoneResponsavel(familia: FamiliaResponse): string {
+    const responsavel = familia.membros.find(membro => membro.responsavelPrincipal);
+    if (!responsavel?.telefone) {
+      return 'Telefone não informado';
+    }
+    return responsavel.telefone;
+  }
+
   obterTotalMembros(familia: FamiliaResponse): number {
     return familia.membros.length;
   }

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -22,7 +22,6 @@ export interface FamiliaPayload {
   bairroId: number | null;
   novoBairro: string | null;
   novaRegiao: string | null;
-  telefone: string;
   membros: FamiliaMembroPayload[];
 }
 

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -72,18 +72,6 @@
           </select>
         </div>
 
-        <div>
-          <label for="telefoneFamilia" class="block text-sm font-semibold text-gray-700 mb-2">Telefone de Contato *</label>
-          <input
-            id="telefoneFamilia"
-            type="tel"
-            placeholder="(11) 99999-9999"
-            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-            [(ngModel)]="familia.telefone"
-            name="telefoneFamilia"
-          />
-        </div>
-
         <div class="md:col-span-2">
           <label class="block text-sm font-semibold text-gray-700 mb-2">CEP</label>
           <div class="flex flex-col space-y-2">
@@ -103,13 +91,6 @@
                   class="px-4 py-2 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {{ enderecoFamilia.carregandoCep ? 'Buscando...' : 'Buscar CEP' }}
-                </button>
-                <button
-                  type="button"
-                  (click)="alternarPreenchimentoManualFamilia()"
-                  class="px-4 py-2 bg-gray-100 text-gray-700 rounded-xl font-medium hover:bg-gray-200 transition-colors"
-                >
-                  {{ enderecoFamilia.preenchimentoManual ? 'Usar CEP' : 'Preencher manualmente' }}
                 </button>
               </div>
             </div>
@@ -281,7 +262,7 @@
               />
             </div>
 
-            <div>
+            <div *ngIf="!membro.responsavel">
               <label class="block text-sm font-semibold text-gray-700 mb-2">Grau de Parentesco *</label>
               <select
                 class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
@@ -291,6 +272,13 @@
                 <option value="">Selecione o parentesco</option>
                 <option *ngFor="let parentesco of grausParentesco" [value]="parentesco">{{ parentesco }}</option>
               </select>
+            </div>
+
+            <div *ngIf="membro.responsavel">
+              <label class="block text-sm font-semibold text-gray-700 mb-2">Grau de Parentesco</label>
+              <div class="w-full px-4 py-3 border-2 border-dashed border-purple-300 rounded-xl bg-purple-50 text-purple-700">
+                Responsável pela família
+              </div>
             </div>
 
             <div class="md:col-span-2">
@@ -329,7 +317,8 @@
                 <input
                   type="tel"
                   class="flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                  [(ngModel)]="membro.telefone"
+                  [ngModel]="membro.telefone"
+                  (ngModelChange)="atualizarTelefoneMembro(i, $event)"
                   name="telefone_{{ i }}"
                   placeholder="(11) 99999-9999"
                 />
@@ -426,12 +415,6 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z"></path>
             </svg>
             {{ previaFamilia.cidade }}<span *ngIf="previaFamilia.cep"> • CEP {{ previaFamilia.cep }}</span>
-          </div>
-          <div class="flex items-center text-gray-600">
-            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
-            </svg>
-            {{ previaFamilia.telefone || 'Telefone não informado' }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Resumo
- remove o telefone da família e o botão de preenchimento manual no cadastro de novas famílias
- aplica máscara e saneamento ao telefone de cada pessoa, ocultando o campo de parentesco quando o membro é responsável
- ajusta a listagem para exibir o telefone do responsável e atualiza o payload sem telefone da família

## Testes
- npm test -- --watch=false (frontend)
- npm test -- --watch=false (backend-java) *(falha: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7df692f48328b50ec4eb52d05833