### PR TITLE
Remover ícone do perfil no menu superior

### DIFF
--- a/frontend/src/app/components/top-nav/top-nav.component.html
+++ b/frontend/src/app/components/top-nav/top-nav.component.html
@@ -70,8 +70,7 @@
             <div class="px-4 pb-3 border-b border-gray-100">
               <div class="text-sm font-semibold text-gray-900">{{ usuario.nome }}</div>
               <div class="text-xs text-gray-500">{{ usuario.usuario }}</div>
-              <div class="mt-1 inline-flex items-center gap-2 text-[11px] text-blue-600 bg-blue-50 px-2 py-1 rounded-full">
-                <span class="w-1.5 h-1.5 rounded-full bg-blue-500"></span>
+              <div class="mt-1 inline-flex items-center text-[11px] text-blue-600 bg-blue-50 px-2 py-1 rounded-full">
                 {{ usuario.perfil === 'ADMINISTRADOR' ? 'Administrador' : 'Usuário' }}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove o ícone do perfil exibido ao lado do rótulo do perfil na navegação superior

## Testing
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68dc7fecc8c48328bb5a4aad6178cb8a