### PR TITLE
Ajusta cadastro de família com CEP e regiões

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/controller/LocalidadeController.java
+++ b/backend-java/src/main/java/com/gestorpolitico/controller/LocalidadeController.java
@@ -2,6 +2,7 @@ package com.gestorpolitico.controller;
 
 import com.gestorpolitico.dto.AtualizarRegiaoBairrosRequestDTO;
 import com.gestorpolitico.dto.BairroResponseDTO;
+import com.gestorpolitico.dto.CidadeRequestDTO;
 import com.gestorpolitico.dto.CidadeResponseDTO;
 import com.gestorpolitico.dto.RegiaoAtribuicaoRequestDTO;
 import com.gestorpolitico.dto.RegiaoRequestDTO;
@@ -32,6 +33,11 @@ public class LocalidadeController {
   @GetMapping("/cidades")
   public ResponseEntity<List<CidadeResponseDTO>> listarCidades() {
     return ResponseEntity.ok(localidadeService.listarCidades());
+  }
+
+  @PostMapping("/cidades")
+  public ResponseEntity<CidadeResponseDTO> criarCidade(@Valid @RequestBody CidadeRequestDTO dto) {
+    return ResponseEntity.ok(localidadeService.criarCidade(dto));
   }
 
   @GetMapping("/cidades/{cidadeId}/bairros")

--- a/backend-java/src/main/java/com/gestorpolitico/dto/CidadeRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/CidadeRequestDTO.java
@@ -1,0 +1,32 @@
+package com.gestorpolitico.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class CidadeRequestDTO {
+  @NotBlank(message = "Informe o nome da cidade.")
+  @Size(max = 150, message = "O nome da cidade deve ter no máximo 150 caracteres.")
+  private String nome;
+
+  @NotBlank(message = "Informe a UF da cidade.")
+  @Size(min = 2, max = 2, message = "A UF deve conter exatamente 2 caracteres.")
+  private String uf;
+
+  public CidadeRequestDTO() {}
+
+  public String getNome() {
+    return nome;
+  }
+
+  public void setNome(String nome) {
+    this.nome = nome;
+  }
+
+  public String getUf() {
+    return uf;
+  }
+
+  public void setUf(String uf) {
+    this.uf = uf;
+  }
+}

--- a/backend-java/src/main/java/com/gestorpolitico/service/LocalidadeService.java
+++ b/backend-java/src/main/java/com/gestorpolitico/service/LocalidadeService.java
@@ -2,6 +2,7 @@ package com.gestorpolitico.service;
 
 import com.gestorpolitico.dto.AtualizarRegiaoBairrosRequestDTO;
 import com.gestorpolitico.dto.BairroResponseDTO;
+import com.gestorpolitico.dto.CidadeRequestDTO;
 import com.gestorpolitico.dto.CidadeResponseDTO;
 import com.gestorpolitico.dto.RegiaoRequestDTO;
 import com.gestorpolitico.dto.RegiaoResponseDTO;
@@ -51,6 +52,27 @@ public class LocalidadeService {
       .sorted(Comparator.comparing(Cidade::getNome, String.CASE_INSENSITIVE_ORDER))
       .map(cidade -> new CidadeResponseDTO(cidade.getId(), cidade.getNome(), cidade.getUf()))
       .toList();
+  }
+
+  @Transactional
+  public CidadeResponseDTO criarCidade(CidadeRequestDTO dto) {
+    String nome = dto.getNome() != null ? dto.getNome().trim() : "";
+    String uf = dto.getUf() != null ? dto.getUf().trim().toUpperCase() : "";
+
+    if (nome.isBlank() || uf.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe nome e UF da cidade.");
+    }
+
+    return cidadeRepository
+      .findByNomeIgnoreCaseAndUfIgnoreCase(nome, uf)
+      .map(existente -> new CidadeResponseDTO(existente.getId(), existente.getNome(), existente.getUf()))
+      .orElseGet(() -> {
+        Cidade cidade = new Cidade();
+        cidade.setNome(nome);
+        cidade.setUf(uf);
+        Cidade salvo = cidadeRepository.save(cidade);
+        return new CidadeResponseDTO(salvo.getId(), salvo.getNome(), salvo.getUf());
+      });
   }
 
   public List<BairroResponseDTO> listarBairros(Long cidadeId, String regiao) {

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -59,19 +59,6 @@
           <p class="text-xs text-gray-500 mt-2">O responsável é definido ao marcar a opção de responsável em um dos membros cadastrados.</p>
         </div>
 
-        <div>
-          <label class="block text-sm font-semibold text-gray-700 mb-2">Cidade *</label>
-          <select
-            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-            [(ngModel)]="enderecoFamilia.cidadeId"
-            name="cidadeFamilia"
-            (ngModelChange)="aoAlterarCidadeFamilia($event)"
-          >
-            <option [ngValue]="null">Selecione a cidade</option>
-            <option *ngFor="let cidade of cidades" [ngValue]="cidade.id">{{ cidade.nome }} - {{ cidade.uf }}</option>
-          </select>
-        </div>
-
         <div class="md:col-span-2">
           <label class="block text-sm font-semibold text-gray-700 mb-2">CEP</label>
           <div class="flex flex-col space-y-2">
@@ -119,30 +106,16 @@
         </div>
 
         <div>
-          <label class="block text-sm font-semibold text-gray-700 mb-2">Região</label>
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Cidade *</label>
           <select
             class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-            [(ngModel)]="enderecoFamilia.regiaoSelecionada"
-            name="regiaoFamilia"
-            (ngModelChange)="aoAlterarRegiaoFamilia($event)"
+            [(ngModel)]="enderecoFamilia.cidadeId"
+            name="cidadeFamilia"
+            (ngModelChange)="aoAlterarCidadeFamilia($event)"
           >
-            <option [ngValue]="null">Selecione a região</option>
-            <option *ngFor="let regiao of enderecoFamilia.regioes" [ngValue]="regiao.nome">{{ regiao.nome }}</option>
-            <option *ngIf="ehAdministrador || novaRegiaoGeradaPorCep" [ngValue]="valorNovaRegiao">
-              Cadastrar nova região
-            </option>
+            <option [ngValue]="null">Selecione a cidade</option>
+            <option *ngFor="let cidade of cidades" [ngValue]="cidade.id">{{ cidade.nome }} - {{ cidade.uf }}</option>
           </select>
-        </div>
-
-        <div *ngIf="enderecoFamilia.regiaoSelecionada === valorNovaRegiao && (ehAdministrador || novaRegiaoGeradaPorCep)">
-          <label class="block text-sm font-semibold text-gray-700 mb-2">Nova Região *</label>
-          <input
-            type="text"
-            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-            [(ngModel)]="enderecoFamilia.novaRegiao"
-            name="novaRegiaoFamilia"
-            placeholder="Informe o nome da nova região"
-          />
         </div>
 
         <div>
@@ -159,6 +132,41 @@
               Cadastrar novo bairro
             </option>
           </select>
+        </div>
+
+        <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Região do bairro</label>
+          <select
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [ngClass]="{ 'bg-gray-100': enderecoFamilia.regiaoBloqueada }"
+            [(ngModel)]="enderecoFamilia.regiaoSelecionada"
+            name="regiaoFamilia"
+            [disabled]="enderecoFamilia.regiaoBloqueada || enderecoFamilia.atualizandoRegiao"
+            (ngModelChange)="aoAlterarRegiaoFamilia($event)"
+          >
+            <option [ngValue]="null">Selecione a região</option>
+            <option *ngFor="let regiao of enderecoFamilia.regioes" [ngValue]="regiao.nome">{{ regiao.nome }}</option>
+            <option *ngIf="!enderecoFamilia.regiaoBloqueada && (ehAdministrador || novaRegiaoGeradaPorCep)" [ngValue]="valorNovaRegiao">
+              Cadastrar nova região
+            </option>
+          </select>
+          <p *ngIf="enderecoFamilia.atualizandoRegiao" class="text-xs text-blue-600 mt-2">Atualizando região do bairro...</p>
+          <p *ngIf="enderecoFamilia.regiaoBloqueada" class="text-xs text-gray-500 mt-2">
+            Região definida para este bairro e bloqueada para edição.
+          </p>
+        </div>
+
+        <div
+          *ngIf="!enderecoFamilia.regiaoBloqueada && enderecoFamilia.regiaoSelecionada === valorNovaRegiao && (ehAdministrador || novaRegiaoGeradaPorCep)"
+        >
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Nova Região *</label>
+          <input
+            type="text"
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [(ngModel)]="enderecoFamilia.novaRegiao"
+            name="novaRegiaoFamilia"
+            placeholder="Informe o nome da nova região"
+          />
         </div>
 
         <div *ngIf="enderecoFamilia.bairroSelecionado === valorNovoBairro && (ehAdministrador || novoBairroGeradoPorCep)">

--- a/frontend/src/app/modules/shared/services/localidades.service.ts
+++ b/frontend/src/app/modules/shared/services/localidades.service.ts
@@ -29,6 +29,10 @@ export class LocalidadesService {
     return this.http.get<Cidade[]>(buildApiUrl('/cidades'));
   }
 
+  criarCidade(payload: { nome: string; uf: string }): Observable<Cidade> {
+    return this.http.post<Cidade>(buildApiUrl('/cidades'), payload);
+  }
+
   listarBairros(cidadeId: number, regiao?: string | null): Observable<Bairro[]> {
     let params = new HttpParams();
     if (regiao) {


### PR DESCRIPTION
## Resumo
- inclui endpoint POST `/cidades` com DTO de criação para permitir cadastro automático de municípios retornados pelo CEP
- reorganiza o formulário de nova família para priorizar CEP, cidade e bairro e buscar/registrar cidade a partir da consulta de CEP
- vincula automaticamente bairros à região configurada, bloqueando edição quando já houver vínculo e permitindo selecionar uma região existente quando o bairro estiver sem definição

## Testes
- `npm test -- --watch=false`
- `npm test` *(falha esperada: diretório backend-java não possui package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68dc83222e8483289282237e7d63ba88