### PR TITLE
feat: integrar fontawesome no mapa

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,10 @@
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
+        "@fortawesome/fontawesome-free": "^6.7.2",
+        "@types/leaflet": "^1.9.20",
         "chart.js": "^4.4.7",
+        "leaflet": "^1.9.4",
         "rxjs": "^7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -2843,6 +2846,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
@@ -5113,6 +5125,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -5136,6 +5154,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.20",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
+      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -8671,6 +8698,12 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/less": {
       "version": "4.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,10 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@types/leaflet": "^1.9.20",
     "chart.js": "^4.4.7",
+    "leaflet": "^1.9.4",
     "rxjs": "^7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -22,6 +22,12 @@ const routes: Routes = [
     loadChildren: () => import('./modules/configuracoes/configuracoes.module').then(m => m.ConfiguracoesModule)
   },
   {
+    path: 'georreferenciamento',
+    canActivate: [AdminGuard],
+    loadChildren: () =>
+      import('./modules/georreferenciamento/georreferenciamento.module').then(m => m.GeoReferenciamentoModule)
+  },
+  {
     path: 'perfil',
     canActivate: [AuthGuard],
     loadChildren: () => import('./modules/perfil/perfil.module').then(m => m.PerfilModule)

--- a/frontend/src/app/components/top-nav/top-nav.component.ts
+++ b/frontend/src/app/components/top-nav/top-nav.component.ts
@@ -90,6 +90,12 @@ export class TopNavComponent implements OnDestroy {
         icon: 'M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 4.34l1.63 1.27a.5.5 0 01-.03.79l-1.94 1.12c-.14.77-',
         route: '/configuracoes'
       });
+      itensBase.push({
+        label: 'GeoReferenciamento',
+        description: 'Mapa das famílias cadastradas',
+        icon: 'M12 11c1.657 0 3-1.343 3-3S13.657 5 12 5s-3 1.343-3 3 1.343 3 3 3zm0 2c-2.21 0-4 1.79-4 4v3h8v-3c0-2.21-1.79-4-4-4zm9-2h-1a1 1 0 01-1-1V9a1 1 0 012 0v1zm-16 0H4a1 1 0 01-1-1V9a1 1 0 012 0v1z',
+        route: '/georreferenciamento'
+      });
     }
 
     return itensBase;

--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -81,6 +81,7 @@
           <div
             *ngFor="let familia of familias"
             class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all"
+            [ngClass]="{ 'border-2 border-emerald-400 shadow-xl': familia.id === familiaSelecionadaId }"
           >
             <div class="flex items-start justify-between">
               <div>

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { FamiliasService, FamiliaResponse } from './familias.service';
 
 @Component({
@@ -16,9 +17,18 @@ export class FamiliasComponent implements OnInit {
   carregando = false;
   erroCarregamento = '';
 
-  constructor(private readonly familiasService: FamiliasService) {}
+  familiaSelecionadaId: number | null = null;
+
+  constructor(private readonly familiasService: FamiliasService, private readonly route: ActivatedRoute) {}
 
   ngOnInit(): void {
+    const familiaIdParam = this.route.snapshot.queryParamMap.get('familiaId');
+    if (familiaIdParam) {
+      const id = Number(familiaIdParam);
+      if (!Number.isNaN(id)) {
+        this.familiaSelecionadaId = id;
+      }
+    }
     this.carregarFamilias();
   }
 

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
@@ -1,0 +1,62 @@
+:host {
+  display: block;
+}
+
+.mapa-container {
+  height: 600px;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.08);
+}
+
+.popup-conteudo {
+  max-width: 220px;
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+
+.popup-conteudo strong {
+  display: block;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.popup-endereco {
+  color: #4b5563;
+  margin-bottom: 0.5rem;
+}
+
+.popup-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: #047857;
+  text-decoration: none;
+}
+
+.popup-link:hover {
+  text-decoration: underline;
+}
+
+.popup-link .fa-solid {
+  font-size: 0.75rem;
+}
+
+.familia-marker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #10b981, #047857);
+  color: #fff;
+  border: 3px solid #fff;
+  box-shadow: 0 10px 15px -3px rgba(4, 120, 87, 0.35);
+}
+
+.familia-marker .fa-solid {
+  font-size: 1rem;
+  filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.35));
+}

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.html
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.html
@@ -1,0 +1,56 @@
+<div class="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50 pb-12">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 space-y-8">
+    <div class="bg-white rounded-3xl shadow-xl border border-gray-100 p-8 flex flex-col gap-6">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+        <div>
+          <div class="inline-flex items-center px-3 py-1 rounded-full bg-green-50 text-green-600 text-xs font-semibold mb-3">
+            Inteligência territorial
+          </div>
+          <h1 class="text-3xl font-bold text-gray-900 mb-2">GeoReferenciamento das famílias</h1>
+          <p class="text-gray-600 max-w-2xl">
+            Visualize no mapa os núcleos familiares com coordenadas cadastradas, identifique responsáveis estratégicos
+            e acesse rapidamente o cadastro de cada família.
+          </p>
+        </div>
+        <div class="bg-gradient-to-r from-green-400 to-emerald-500 text-white rounded-3xl px-6 py-4 shadow-lg">
+          <div class="text-sm uppercase tracking-wider opacity-80">Famílias georreferenciadas</div>
+          <div class="text-3xl font-semibold">{{ familiasLocalizadas.length }}</div>
+        </div>
+      </div>
+
+      <div class="relative">
+        <div *ngIf="carregando" class="absolute inset-0 z-10 flex items-center justify-center bg-white/80 rounded-3xl">
+          <div class="text-gray-600 font-medium">Carregando mapa e famílias...</div>
+        </div>
+        <div *ngIf="erroCarregamento" class="absolute inset-0 z-10 flex items-center justify-center bg-red-50 rounded-3xl">
+          <div class="text-red-600 font-semibold">{{ erroCarregamento }}</div>
+        </div>
+        <div
+          *ngIf="!carregando && !erroCarregamento && familiasLocalizadas.length === 0"
+          class="absolute inset-0 z-10 flex items-center justify-center bg-white/90 rounded-3xl text-gray-500 text-center px-6"
+        >
+          Nenhuma família possui latitude e longitude cadastradas até o momento.
+        </div>
+        <div id="geo-map" class="mapa-container"></div>
+      </div>
+
+      <div class="bg-white rounded-2xl border border-gray-100 p-6 shadow-inner">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">Como funciona</h2>
+        <ul class="grid md:grid-cols-3 gap-4 text-sm text-gray-600">
+          <li class="flex items-start gap-3">
+            <span class="w-8 h-8 rounded-xl bg-green-100 text-green-600 font-semibold flex items-center justify-center">1</span>
+            <span>Buscamos todas as famílias cadastradas e filtramos apenas aquelas com coordenadas geográficas válidas.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-8 h-8 rounded-xl bg-green-100 text-green-600 font-semibold flex items-center justify-center">2</span>
+            <span>Os marcadores exibem o responsável principal e o endereço completo informado no cadastro.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-8 h-8 rounded-xl bg-green-100 text-green-600 font-semibold flex items-center justify-center">3</span>
+            <span>Ao clicar em um ponto do mapa, acesse rapidamente o cadastro da família em uma nova aba.</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -1,0 +1,192 @@
+import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import * as L from 'leaflet';
+import { Subscription } from 'rxjs';
+import { FamiliasService, FamiliaResponse, EnderecoFamiliaResponse } from '../familias/familias.service';
+interface FamiliaLocalizada {
+  id: number;
+  responsavel: string;
+  enderecoCompleto: string;
+  latitude: number;
+  longitude: number;
+  link: string;
+}
+
+@Component({
+  standalone: false,
+  selector: 'app-georreferenciamento',
+  templateUrl: './georreferenciamento.component.html',
+  styleUrls: ['./georreferenciamento.component.css']
+})
+export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDestroy {
+  carregando = false;
+  erroCarregamento = '';
+  familiasLocalizadas: FamiliaLocalizada[] = [];
+  private mapa: L.Map | null = null;
+  private camadaMarcadores: L.LayerGroup | null = null;
+  private assinaturaFamilias: Subscription | null = null;
+  private readonly iconeFamilia = L.divIcon({
+    html: '<i class="fa-solid fa-people-roof" aria-hidden="true"></i>',
+    className: 'familia-marker',
+    iconSize: [36, 36],
+    iconAnchor: [18, 36],
+    popupAnchor: [0, -28]
+  });
+
+  constructor(private readonly familiasService: FamiliasService, private readonly router: Router) {}
+
+  ngOnInit(): void {
+    this.carregarFamilias();
+  }
+
+  ngAfterViewInit(): void {
+    this.inicializarMapa();
+    this.atualizarMapa();
+  }
+
+  ngOnDestroy(): void {
+    this.assinaturaFamilias?.unsubscribe();
+    if (this.mapa) {
+      this.mapa.remove();
+      this.mapa = null;
+    }
+  }
+
+  private carregarFamilias(): void {
+    this.carregando = true;
+    this.erroCarregamento = '';
+    this.assinaturaFamilias = this.familiasService.listarFamilias().subscribe({
+      next: familias => {
+        this.familiasLocalizadas = familias
+          .map(familia => this.converterFamilia(familia))
+          .filter((familia): familia is FamiliaLocalizada => familia !== null);
+        this.carregando = false;
+        this.atualizarMapa();
+      },
+      error: erro => {
+        console.error('Erro ao carregar famílias para georreferenciamento', erro);
+        this.erroCarregamento = 'Não foi possível carregar as famílias cadastradas.';
+        this.carregando = false;
+      }
+    });
+  }
+
+  private inicializarMapa(): void {
+    if (this.mapa) {
+      return;
+    }
+    this.mapa = L.map('geo-map', {
+      center: [-14.235004, -51.92528],
+      zoom: 5,
+      attributionControl: false
+    });
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contribuidores'
+    }).addTo(this.mapa);
+  }
+
+  private atualizarMapa(): void {
+    if (!this.mapa) {
+      return;
+    }
+
+    if (!this.camadaMarcadores) {
+      this.camadaMarcadores = L.layerGroup().addTo(this.mapa);
+    }
+    this.camadaMarcadores.clearLayers();
+
+    if (this.familiasLocalizadas.length === 0) {
+      return;
+    }
+
+    const coordenadas: L.LatLngExpression[] = [];
+    this.familiasLocalizadas.forEach(familia => {
+      const marcador = this.criarMarcador(familia);
+      marcador.addTo(this.camadaMarcadores as L.LayerGroup);
+      coordenadas.push([familia.latitude, familia.longitude]);
+    });
+
+    if (coordenadas.length === 1) {
+      this.mapa.setView(coordenadas[0], 15);
+    } else {
+      const limites = L.latLngBounds(coordenadas);
+      this.mapa.fitBounds(limites, { padding: [40, 40] });
+    }
+  }
+
+  private converterFamilia(familia: FamiliaResponse): FamiliaLocalizada | null {
+    const enderecoDetalhado = familia.enderecoDetalhado;
+    if (!enderecoDetalhado) {
+      return null;
+    }
+
+    const { latitude, longitude } = enderecoDetalhado;
+    if (latitude === null || latitude === undefined || longitude === null || longitude === undefined) {
+      return null;
+    }
+
+    return {
+      id: familia.id,
+      responsavel: this.obterResponsavel(familia),
+      enderecoCompleto: this.montarEndereco(enderecoDetalhado),
+      latitude,
+      longitude,
+      link: this.montarLinkFamilia(familia.id)
+    };
+  }
+
+  private obterResponsavel(familia: FamiliaResponse): string {
+    const responsavel = familia.membros.find(membro => membro.responsavelPrincipal);
+    return responsavel?.nomeCompleto || 'Responsável não informado';
+  }
+
+  private montarEndereco(endereco: EnderecoFamiliaResponse): string {
+    const partes = [endereco.rua, endereco.numero, endereco.bairro, `${endereco.cidade}/${endereco.uf}`]
+      .filter(parte => !!parte && parte !== 'null');
+    return partes.join(', ');
+  }
+
+  private montarLinkFamilia(id: number): string {
+    const urlTree = this.router.createUrlTree(['/familias'], { queryParams: { familiaId: id } });
+    const url = this.router.serializeUrl(urlTree);
+    if (typeof window !== 'undefined' && window.location) {
+      return `${window.location.origin}${url}`;
+    }
+    return url;
+  }
+
+  private criarConteudoPopup(familia: FamiliaLocalizada): string {
+    const titulo = this.escapeHtml(`Família de ${familia.responsavel}`);
+    const endereco = this.escapeHtml(familia.enderecoCompleto);
+    const link = this.escapeHtml(familia.link);
+    return `
+      <div class="popup-conteudo">
+        <strong>${titulo}</strong>
+        <div class="popup-endereco">${endereco}</div>
+        <a href="${link}" target="_blank" rel="noopener" class="popup-link">
+          <i class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i>
+          <span>Abrir cadastro</span>
+        </a>
+      </div>
+    `;
+  }
+
+  private criarMarcador(familia: FamiliaLocalizada): L.Marker {
+    return L.marker([familia.latitude, familia.longitude], {
+      icon: this.iconeFamilia
+    }).bindPopup(this.criarConteudoPopup(familia));
+  }
+
+  private escapeHtml(valor: string): string {
+    const mapaCaracteres: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    };
+    return valor.replace(/[&<>"']/g, caractere => mapaCaracteres[caractere]);
+  }
+}

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.module.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { GeoReferenciamentoComponent } from './georreferenciamento.component';
+
+const routes: Routes = [
+  { path: '', component: GeoReferenciamentoComponent }
+];
+
+@NgModule({
+  declarations: [GeoReferenciamentoComponent],
+  imports: [CommonModule, RouterModule.forChild(routes)]
+})
+export class GeoReferenciamentoModule {}

--- a/frontend/src/assets/leaflet/README.md
+++ b/frontend/src/assets/leaflet/README.md
@@ -1,0 +1,9 @@
+# Ícones do Leaflet
+
+Adicione nesta pasta os arquivos de ícones padrão do Leaflet para que os marcadores sejam exibidos corretamente no mapa:
+
+- `marker-icon.png`
+- `marker-icon-2x.png`
+- `marker-shadow.png`
+
+Os arquivos podem ser obtidos diretamente do repositório oficial do Leaflet ou do pacote distribuído via CDN. Mantenha os nomes acima para que o sistema os localize automaticamente.

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,3 +1,6 @@
+@import 'leaflet/dist/leaflet.css';
+@import '@fortawesome/fontawesome-free/css/all.min.css';
+
 .gradient-blue {
   background: linear-gradient(135deg, #3B82F6 0%, #2563EB 100%);
 }


### PR DESCRIPTION
## Resumo
- adiciona Font Awesome às dependências globais do frontend
- substitui os marcadores do Leaflet por ícones do Font Awesome com popup atualizado
- estiliza o mapa para suportar os novos ícones vetoriais

## Testes
- `npm test` (frontend)
- `npm test` (backend-java) *(falhou: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7fb4c69c8328934ac392c5ade3e1