### PR TITLE
Remove CPF do cadastro de membros

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
@@ -2,7 +2,6 @@ package com.gestorpolitico.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Past;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -11,10 +10,6 @@ public class MembroFamiliaRequestDTO {
   @NotBlank(message = "O nome completo é obrigatório.")
   @Size(max = 255, message = "O nome completo deve ter no máximo 255 caracteres.")
   private String nomeCompleto;
-
-  @NotBlank(message = "O CPF é obrigatório.")
-  @Pattern(regexp = "\\d{11}|\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}", message = "Informe um CPF válido.")
-  private String cpf;
 
   @Past(message = "A data de nascimento deve estar no passado.")
   private LocalDate dataNascimento;
@@ -43,14 +38,6 @@ public class MembroFamiliaRequestDTO {
 
   public void setNomeCompleto(String nomeCompleto) {
     this.nomeCompleto = nomeCompleto;
-  }
-
-  public String getCpf() {
-    return cpf;
-  }
-
-  public void setCpf(String cpf) {
-    this.cpf = cpf;
   }
 
   public LocalDate getDataNascimento() {

--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
@@ -6,7 +6,6 @@ import java.time.OffsetDateTime;
 public class MembroFamiliaResponseDTO {
   private Long id;
   private String nomeCompleto;
-  private String cpf;
   private LocalDate dataNascimento;
   private String profissao;
   private String parentesco;
@@ -21,7 +20,6 @@ public class MembroFamiliaResponseDTO {
   public MembroFamiliaResponseDTO(
     Long id,
     String nomeCompleto,
-    String cpf,
     LocalDate dataNascimento,
     String profissao,
     String parentesco,
@@ -32,7 +30,6 @@ public class MembroFamiliaResponseDTO {
   ) {
     this.id = id;
     this.nomeCompleto = nomeCompleto;
-    this.cpf = cpf;
     this.dataNascimento = dataNascimento;
     this.profissao = profissao;
     this.parentesco = parentesco;
@@ -56,14 +53,6 @@ public class MembroFamiliaResponseDTO {
 
   public void setNomeCompleto(String nomeCompleto) {
     this.nomeCompleto = nomeCompleto;
-  }
-
-  public String getCpf() {
-    return cpf;
-  }
-
-  public void setCpf(String cpf) {
-    this.cpf = cpf;
   }
 
   public LocalDate getDataNascimento() {

--- a/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
@@ -12,7 +12,6 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -28,11 +27,6 @@ public class MembroFamilia {
   @Size(max = 255)
   @Column(name = "nome_completo", nullable = false, length = 255)
   private String nomeCompleto;
-
-  @NotBlank
-  @Pattern(regexp = "\\d{11}")
-  @Column(nullable = false, length = 11, unique = true)
-  private String cpf;
 
   @Column(name = "data_nascimento")
   private LocalDate dataNascimento;
@@ -76,14 +70,6 @@ public class MembroFamilia {
 
   public void setNomeCompleto(String nomeCompleto) {
     this.nomeCompleto = nomeCompleto;
-  }
-
-  public String getCpf() {
-    return cpf;
-  }
-
-  public void setCpf(String cpf) {
-    this.cpf = cpf;
   }
 
   public LocalDate getDataNascimento() {

--- a/backend-java/src/main/java/com/gestorpolitico/repository/MembroFamiliaRepository.java
+++ b/backend-java/src/main/java/com/gestorpolitico/repository/MembroFamiliaRepository.java
@@ -1,9 +1,6 @@
 package com.gestorpolitico.repository;
 
 import com.gestorpolitico.entity.MembroFamilia;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MembroFamiliaRepository extends JpaRepository<MembroFamilia, Long> {
-  Optional<MembroFamilia> findByCpf(String cpf);
-}
+public interface MembroFamiliaRepository extends JpaRepository<MembroFamilia, Long> {}

--- a/backend-java/src/main/resources/db/ddl.sql
+++ b/backend-java/src/main/resources/db/ddl.sql
@@ -53,7 +53,6 @@ CREATE TABLE IF NOT EXISTS familia (
 CREATE TABLE IF NOT EXISTS membro_familia (
   id BIGSERIAL PRIMARY KEY,
   nome_completo VARCHAR(255) NOT NULL,
-  cpf VARCHAR(11) NOT NULL UNIQUE,
   data_nascimento DATE,
   profissao VARCHAR(255),
   parentesco VARCHAR(255) NOT NULL,

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -5,7 +5,6 @@ import { buildApiUrl } from '../shared/api-url.util';
 
 export interface FamiliaMembroPayload {
   nomeCompleto: string;
-  cpf: string;
   dataNascimento: string | null;
   profissao: string | null;
   parentesco: string;
@@ -39,7 +38,6 @@ export interface EnderecoFamiliaResponse {
 export interface FamiliaMembroResponse {
   id: number;
   nomeCompleto: string;
-  cpf: string;
   dataNascimento: string | null;
   profissao: string | null;
   parentesco: string;

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -232,14 +232,29 @@
             </div>
 
             <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">CPF *</label>
-              <input
-                type="text"
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [(ngModel)]="membro.cpf"
-                name="cpf_{{ i }}"
-                placeholder="000.000.000-00"
-              />
+              <label class="block text-sm font-semibold text-gray-700 mb-2">Telefone de Contato</label>
+              <div class="flex items-center space-x-2">
+                <input
+                  type="tel"
+                  class="flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+                  [ngModel]="membro.telefone"
+                  (ngModelChange)="atualizarTelefoneMembro(i, $event)"
+                  name="telefone_{{ i }}"
+                  placeholder="(11) 99999-9999"
+                />
+                <button
+                  type="button"
+                  (click)="abrirWhatsApp(membro.telefone)"
+                  class="p-3 bg-green-100 text-green-600 rounded-xl hover:bg-green-200 transition-colors"
+                  title="Chamar no WhatsApp"
+                >
+                  <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 32 32" aria-hidden="true">
+                    <path
+                      d="M16.003 2.667c-7.364 0-13.333 5.969-13.333 13.333 0 2.352.612 4.643 1.777 6.667L2.667 29.333l6.8-1.753a13.266 13.266 0 006.536 1.72h.004c7.36 0 13.33-5.969 13.33-13.333 0-3.563-1.387-6.917-3.904-9.437-2.515-2.52-5.867-3.863-9.33-3.863zm-.004 24c-2.12 0-4.2-.567-6.016-1.64l-.432-.256-4.032 1.04 1.072-3.933-.28-.404a11.264 11.264 0 01-1.732-5.973c0-6.24 5.088-11.333 11.336-11.333 3.027 0 5.876 1.18 8.016 3.32a11.267 11.267 0 013.32 8.02c0 6.243-5.087 11.329-11.32 11.329zm6.192-8.429c-.339-.17-2.012-.993-2.324-1.105-.312-.114-.539-.17-.766.169-.226.339-.877 1.105-1.074 1.333-.198.226-.395.255-.734.085-.339-.17-1.433-.527-2.732-1.68-1.01-.9-1.69-2.017-1.888-2.356-.198-.339-.021-.522.149-.692.153-.152.339-.395.509-.593.17-.198.226-.339.339-.565.113-.226.057-.424-.028-.593-.085-.17-.766-1.848-1.05-2.528-.276-.663-.558-.572-.766-.582l-.653-.012c-.197 0-.52.074-.792.372-.272.339-1.04 1.016-1.04 2.48 0 1.463 1.064 2.876 1.213 3.074.149.197 2.095 3.2 5.077 4.486.71.306 1.264.489 1.695.624.712.227 1.36.195 1.872.118.571-.085 1.75-.715 1.997-1.403.247-.688.247-1.277.173-1.403-.074-.127-.272-.198-.61-.368z"
+                    ></path>
+                  </svg>
+                </button>
+              </div>
             </div>
 
             <div>
@@ -281,22 +296,6 @@
               </div>
             </div>
 
-            <div class="md:col-span-2">
-              <div class="flex items-center space-x-3 mt-2 md:mt-0">
-                <input
-                  type="checkbox"
-                  class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                  [id]="'responsavel_' + i"
-                  [checked]="membro.responsavel"
-                  (change)="definirResponsavel(i, $event.target.checked)"
-                />
-                <label [for]="'responsavel_' + i" class="text-sm font-semibold text-gray-700">
-                  Responsável pela família
-                </label>
-              </div>
-              <p class="text-xs text-gray-500 mt-2">Somente um membro pode ser o responsável principal por vez.</p>
-            </div>
-
             <div>
               <label class="block text-sm font-semibold text-gray-700 mb-2">Probabilidade de Voto *</label>
               <select
@@ -311,30 +310,20 @@
               </select>
             </div>
 
-            <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">Telefone de Contato</label>
-              <div class="flex items-center space-x-2">
+            <div class="md:col-span-2">
+              <div class="flex items-center space-x-3 mt-2 md:mt-0">
                 <input
-                  type="tel"
-                  class="flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                  [ngModel]="membro.telefone"
-                  (ngModelChange)="atualizarTelefoneMembro(i, $event)"
-                  name="telefone_{{ i }}"
-                  placeholder="(11) 99999-9999"
+                  type="checkbox"
+                  class="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  [id]="'responsavel_' + i"
+                  [checked]="membro.responsavel"
+                  (change)="definirResponsavel(i, $event.target.checked)"
                 />
-                <button
-                  type="button"
-                  (click)="abrirWhatsApp(membro.telefone)"
-                  class="p-3 bg-green-100 text-green-600 rounded-xl hover:bg-green-200 transition-colors"
-                  title="Chamar no WhatsApp"
-                >
-                  <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 32 32" aria-hidden="true">
-                    <path
-                      d="M16.003 2.667c-7.364 0-13.333 5.969-13.333 13.333 0 2.352.612 4.643 1.777 6.667L2.667 29.333l6.8-1.753a13.266 13.266 0 006.536 1.72h.004c7.36 0 13.33-5.969 13.33-13.333 0-3.563-1.387-6.917-3.904-9.437-2.515-2.52-5.867-3.863-9.33-3.863zm-.004 24c-2.12 0-4.2-.567-6.016-1.64l-.432-.256-4.032 1.04 1.072-3.933-.28-.404a11.264 11.264 0 01-1.732-5.973c0-6.24 5.088-11.333 11.336-11.333 3.027 0 5.876 1.18 8.016 3.32a11.267 11.267 0 013.32 8.02c0 6.243-5.087 11.329-11.32 11.329zm6.192-8.429c-.339-.17-2.012-.993-2.324-1.105-.312-.114-.539-.17-.766.169-.226.339-.877 1.105-1.074 1.333-.198.226-.395.255-.734.085-.339-.17-1.433-.527-2.732-1.68-1.01-.9-1.69-2.017-1.888-2.356-.198-.339-.021-.522.149-.692.153-.152.339-.395.509-.593.17-.198.226-.339.339-.565.113-.226.057-.424-.028-.593-.085-.17-.766-1.848-1.05-2.528-.276-.663-.558-.572-.766-.582l-.653-.012c-.197 0-.52.074-.792.372-.272.339-1.04 1.016-1.04 2.48 0 1.463 1.064 2.876 1.213 3.074.149.197 2.095 3.2 5.077 4.486.71.306 1.264.489 1.695.624.712.227 1.36.195 1.872.118.571-.085 1.75-.715 1.997-1.403.247-.688.247-1.277.173-1.403-.074-.127-.272-.198-.61-.368z"
-                    ></path>
-                  </svg>
-                </button>
+                <label [for]="'responsavel_' + i" class="text-sm font-semibold text-gray-700">
+                  Responsável pela família
+                </label>
               </div>
+              <p class="text-xs text-gray-500 mt-2">Somente um membro pode ser o responsável principal por vez.</p>
             </div>
 
                         <!-- Campos de endereço removidos dos membros -->

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -30,7 +30,6 @@ const PARENTESCO_RESPONSAVEL: GrauParentesco = 'Responsável pela família';
 
 interface MembroFamiliaForm {
   nome: string;
-  cpf: string;
   nascimento: string;
   profissao: string;
   parentesco: GrauParentesco;
@@ -41,7 +40,6 @@ interface MembroFamiliaForm {
 
 interface PreviaMembro {
   nome: string;
-  cpf: string;
   idade: number | null;
   profissao: string;
   parentesco: GrauParentesco;
@@ -493,7 +491,6 @@ export class NovaFamiliaComponent implements OnInit {
   private criarMembro(responsavelPrincipal: boolean): MembroFamiliaForm {
     return {
       nome: '',
-      cpf: '',
       nascimento: '',
       profissao: '',
       parentesco: responsavelPrincipal ? PARENTESCO_RESPONSAVEL : '',
@@ -561,16 +558,10 @@ export class NovaFamiliaComponent implements OnInit {
       const nascimento = membro.nascimento?.trim() || '';
       const probabilidade = this.normalizarTexto(membro.probabilidade);
       const parentesco = this.normalizarTexto(membro.parentesco);
-      const cpf = membro.cpf.replace(/\D/g, '');
       const responsavel = this.normalizarResponsavel(membro.responsavel);
 
       if (!nome || !nascimento || !probabilidade || (!responsavel && !parentesco)) {
         window.alert(`Preencha todos os campos obrigatórios do ${indice + 1}º membro da família.`);
-        return false;
-      }
-
-      if (cpf.length !== 11) {
-        window.alert(`Informe um CPF válido para o ${indice + 1}º membro da família.`);
         return false;
       }
     }
@@ -606,7 +597,6 @@ export class NovaFamiliaComponent implements OnInit {
   private mapearMembroPayload(membro: MembroFamiliaForm): FamiliaMembroPayload {
     return {
       nomeCompleto: membro.nome.trim(),
-      cpf: membro.cpf.replace(/\D/g, ''),
       dataNascimento: membro.nascimento || null,
       profissao: membro.profissao ? membro.profissao.trim() : null,
       parentesco: membro.responsavel ? PARENTESCO_RESPONSAVEL : membro.parentesco,
@@ -675,7 +665,6 @@ export class NovaFamiliaComponent implements OnInit {
   private gerarDadosFamilia(incluirIdade = true): PreviaFamilia {
     const membros: PreviaMembro[] = this.membros.map(membro => ({
       nome: this.normalizarTexto(membro.nome),
-      cpf: this.formatarCpf(membro.cpf),
       idade: incluirIdade ? this.calcularIdade(membro.nascimento) : null,
       profissao: this.normalizarTexto(membro.profissao),
       parentesco: membro.responsavel
@@ -779,11 +768,4 @@ export class NovaFamiliaComponent implements OnInit {
     return idade;
   }
 
-  private formatarCpf(cpf: string): string {
-    const somenteNumeros = cpf.replace(/\D/g, '');
-    if (somenteNumeros.length !== 11) {
-      return somenteNumeros;
-    }
-    return `${somenteNumeros.substring(0, 3)}.${somenteNumeros.substring(3, 6)}.${somenteNumeros.substring(6, 9)}-${somenteNumeros.substring(9)}`;
-  }
 }


### PR DESCRIPTION
## Resumo
- remove o campo de CPF do formulário de cadastro de membros e da prévia
- reordena os campos do cadastro de pessoas para seguir a nova ordem solicitada
- ajusta interfaces e backend para aceitar membros sem CPF

## Testes
- npm test -- --watch=false (frontend)
- cd backend && npm test *(falha: diretório inexistente)*

------
https://chatgpt.com/codex/tasks/task_e_68dc848cc1408328854a353aad68369a