### PR TITLE
Adicionar telefone obrigatório ao cadastro de família

### DIFF
--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -19,6 +19,7 @@ export interface FamiliaPayload {
   numero: string;
   cidadeId: number;
   novaRegiao: string | null;
+  telefone: string;
   membros: FamiliaMembroPayload[];
 }
 

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -106,6 +106,18 @@
         </div>
 
         <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-2">Telefone da Família *</label>
+          <input
+            type="tel"
+            class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
+            [ngModel]="enderecoFamilia.telefone"
+            (ngModelChange)="atualizarTelefoneFamilia($event)"
+            name="telefoneFamilia"
+            placeholder="(34) 99999-9999"
+          />
+        </div>
+
+        <div>
           <label class="block text-sm font-semibold text-gray-700 mb-2">Cidade *</label>
           <select
             class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
@@ -412,6 +424,12 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z"></path>
             </svg>
             {{ previaFamilia.cidade }}<span *ngIf="previaFamilia.cep"> • CEP {{ previaFamilia.cep }}</span>
+          </div>
+          <div class="flex items-center text-gray-600">
+            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3l2 4-2 2a11 11 0 005 5l2-2 4 2v3a2 2 0 01-2 2h-1C9.716 17 7 14.284 7 11V9a2 2 0 01-2-2V5z"></path>
+            </svg>
+            {{ previaFamilia.telefone || 'Telefone não informado' }}
           </div>
         </div>
       </div>

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -57,6 +57,7 @@ interface FamiliaEnderecoForm {
   novaRegiao: string;
   bairroSelecionado: string | null;
   novoBairro: string;
+  telefone: string;
   regiaoBloqueada: boolean;
   atualizandoRegiao: boolean;
   carregandoCep: boolean;
@@ -72,6 +73,7 @@ interface PreviaFamilia {
   regiao: string;
   cidade: string;
   cep: string;
+  telefone: string;
   membros: PreviaMembro[];
 }
 
@@ -175,6 +177,10 @@ export class NovaFamiliaComponent implements OnInit {
               : membro.parentesco
         };
       });
+      const telefoneResponsavel = this.membros[indice].telefone?.trim();
+      if (telefoneResponsavel && !this.enderecoFamilia.telefone.trim()) {
+        this.atualizarTelefoneFamilia(telefoneResponsavel);
+      }
       return;
     }
 
@@ -713,6 +719,7 @@ export class NovaFamiliaComponent implements OnInit {
       novaRegiao: '',
       bairroSelecionado: null,
       novoBairro: '',
+      telefone: '',
       regiaoBloqueada: false,
       atualizandoRegiao: false,
       carregandoCep: false,
@@ -731,6 +738,8 @@ export class NovaFamiliaComponent implements OnInit {
     const novoBairro = this.normalizarTexto(this.enderecoFamilia.novoBairro);
     const regiaoSelecionada = this.enderecoFamilia.regiaoSelecionada;
     const novaRegiao = this.normalizarTexto(this.enderecoFamilia.novaRegiao);
+    const telefoneFamilia = this.enderecoFamilia.telefone.trim();
+    const telefoneSanitizado = this.obterTelefoneLimpo(telefoneFamilia);
 
     if (!rua || !numero) {
       window.alert('Por favor, preencha rua e número da família.');
@@ -754,6 +763,11 @@ export class NovaFamiliaComponent implements OnInit {
 
     if (regiaoSelecionada === this.valorNovaRegiao && !novaRegiao) {
       window.alert('Informe o nome da nova região da família.');
+      return false;
+    }
+
+    if (!telefoneSanitizado) {
+      window.alert('Informe um telefone de contato válido para a família.');
       return false;
     }
 
@@ -788,6 +802,10 @@ export class NovaFamiliaComponent implements OnInit {
       regiaoSelecionada === this.valorNovaRegiao
         ? this.enderecoFamilia.novaRegiao.trim() || null
         : regiaoSelecionada?.trim() || null;
+    const telefoneSanitizado = this.obterTelefoneLimpo(this.enderecoFamilia.telefone);
+    if (!telefoneSanitizado) {
+      throw new Error('Telefone da família inválido.');
+    }
 
     return {
       cep: this.enderecoFamilia.cep ? this.enderecoFamilia.cep.trim() : null,
@@ -795,6 +813,7 @@ export class NovaFamiliaComponent implements OnInit {
       numero: this.enderecoFamilia.numero.trim(),
       cidadeId: this.enderecoFamilia.cidadeId!,
       novaRegiao,
+      telefone: telefoneSanitizado,
       membros
     };
   }
@@ -814,6 +833,10 @@ export class NovaFamiliaComponent implements OnInit {
   atualizarTelefoneMembro(indice: number, valor: string): void {
     const telefoneFormatado = this.aplicarMascaraTelefone(valor);
     this.membros[indice].telefone = telefoneFormatado;
+  }
+
+  atualizarTelefoneFamilia(valor: string): void {
+    this.enderecoFamilia.telefone = this.aplicarMascaraTelefone(valor);
   }
 
   private aplicarMascaraTelefone(valor: string): string {
@@ -885,6 +908,7 @@ export class NovaFamiliaComponent implements OnInit {
     const regiao = this.obterDescricaoRegiaoFamilia();
     const cidade = this.obterDescricaoCidadeFamilia() || 'Cidade não informada';
     const cep = this.enderecoFamilia.cep.trim();
+    const telefone = this.enderecoFamilia.telefone.trim();
 
     return {
       responsavelPrincipal: this.obterResponsavelPrincipal(),
@@ -893,6 +917,7 @@ export class NovaFamiliaComponent implements OnInit {
       regiao,
       cidade,
       cep,
+      telefone,
       membros
     };
   }


### PR DESCRIPTION
## Summary
- adiciona campo de telefone da família no formulário e na pré-visualização de nova família
- valida e formata o telefone antes de enviar o payload para criação da família
- atualiza o serviço de famílias para incluir o telefone obrigatório no payload da API

## Testing
- npm test -- --watch=false
- npm test *(falha: backend-java não possui package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68dc89739570832895481d11cec25cdc