### PR TITLE
Transforma parentesco em enum

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
@@ -1,9 +1,10 @@
 package com.gestorpolitico.dto;
 
+import com.gestorpolitico.enums.Parentesco;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public class MembroFamiliaRequestDTO {
@@ -17,8 +18,8 @@ public class MembroFamiliaRequestDTO {
   @Size(max = 255, message = "A profissão deve ter no máximo 255 caracteres.")
   private String profissao;
 
-  @NotBlank(message = "O parentesco é obrigatório.")
-  private String parentesco;
+  @NotNull(message = "O parentesco é obrigatório.")
+  private Parentesco parentesco;
 
   @NotNull(message = "Informe se é responsável principal.")
   private Boolean responsavelPrincipal;
@@ -56,11 +57,11 @@ public class MembroFamiliaRequestDTO {
     this.profissao = profissao;
   }
 
-  public String getParentesco() {
+  public Parentesco getParentesco() {
     return parentesco;
   }
 
-  public void setParentesco(String parentesco) {
+  public void setParentesco(Parentesco parentesco) {
     this.parentesco = parentesco;
   }
 

--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
@@ -1,5 +1,6 @@
 package com.gestorpolitico.dto;
 
+import com.gestorpolitico.enums.Parentesco;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
@@ -8,7 +9,7 @@ public class MembroFamiliaResponseDTO {
   private String nomeCompleto;
   private LocalDate dataNascimento;
   private String profissao;
-  private String parentesco;
+  private Parentesco parentesco;
   private boolean responsavelPrincipal;
   private String probabilidadeVoto;
   private String telefone;
@@ -22,7 +23,7 @@ public class MembroFamiliaResponseDTO {
     String nomeCompleto,
     LocalDate dataNascimento,
     String profissao,
-    String parentesco,
+    Parentesco parentesco,
     boolean responsavelPrincipal,
     String probabilidadeVoto,
     String telefone,
@@ -71,11 +72,11 @@ public class MembroFamiliaResponseDTO {
     this.profissao = profissao;
   }
 
-  public String getParentesco() {
+  public Parentesco getParentesco() {
     return parentesco;
   }
 
-  public void setParentesco(String parentesco) {
+  public void setParentesco(Parentesco parentesco) {
     this.parentesco = parentesco;
   }
 

--- a/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
@@ -1,7 +1,10 @@
 package com.gestorpolitico.entity;
 
+import com.gestorpolitico.enums.Parentesco;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,9 +37,10 @@ public class MembroFamilia {
   @Size(max = 255)
   private String profissao;
 
-  @NotBlank
+  @NotNull
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false)
-  private String parentesco;
+  private Parentesco parentesco;
 
   @NotNull
   @Column(name = "responsavel_principal", nullable = false)
@@ -88,11 +92,11 @@ public class MembroFamilia {
     this.profissao = profissao;
   }
 
-  public String getParentesco() {
+  public Parentesco getParentesco() {
     return parentesco;
   }
 
-  public void setParentesco(String parentesco) {
+  public void setParentesco(Parentesco parentesco) {
     this.parentesco = parentesco;
   }
 

--- a/backend-java/src/main/java/com/gestorpolitico/enums/Parentesco.java
+++ b/backend-java/src/main/java/com/gestorpolitico/enums/Parentesco.java
@@ -1,0 +1,61 @@
+package com.gestorpolitico.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.text.Normalizer;
+import java.util.Arrays;
+import java.util.Locale;
+
+public enum Parentesco {
+  PAI("Pai"),
+  MAE("Mãe"),
+  FILHO_A("Filho(a)"),
+  FILHA("Filha"),
+  FILHO("Filho"),
+  IRMAO_A("Irmão(ã)"),
+  PRIMO_A("Primo(a)"),
+  TIO_A("Tio(a)"),
+  SOBRINHO_A("Sobrinho(a)"),
+  CONJUGE("Cônjuge"),
+  AVO_O("Avô(ó)"),
+  ENTEADO_A("Enteado(a)"),
+  RESPONSAVEL("Responsável pela família"),
+  OUTRO("Outro");
+
+  private final String descricao;
+
+  Parentesco(String descricao) {
+    this.descricao = descricao;
+  }
+
+  @JsonCreator
+  public static Parentesco fromValue(String valor) {
+    if (valor == null) {
+      return null;
+    }
+
+    String normalizado = normalizar(valor);
+    return Arrays
+      .stream(values())
+      .filter(item -> normalizar(item.descricao).equals(normalizado) || normalizar(item.name()).equals(normalizado))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("Parentesco inválido: " + valor));
+  }
+
+  private static String normalizar(String valor) {
+    return Normalizer
+      .normalize(valor, Normalizer.Form.NFD)
+      .replaceAll("\\p{InCombiningDiacriticalMarks}+", "")
+      .replaceAll("[^A-Za-z]", "")
+      .toLowerCase(Locale.ROOT);
+  }
+
+  @JsonValue
+  public String getCodigo() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+
+  public String getDescricao() {
+    return descricao;
+  }
+}

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { buildApiUrl } from '../shared/api-url.util';
+import { GrauParentesco } from './parentesco.enum';
 
 export interface FamiliaMembroPayload {
   nomeCompleto: string;
   dataNascimento: string | null;
   profissao: string | null;
-  parentesco: string;
+  parentesco: GrauParentesco;
   responsavelPrincipal: boolean;
   probabilidadeVoto: string;
   telefone: string | null;
@@ -40,7 +41,7 @@ export interface FamiliaMembroResponse {
   nomeCompleto: string;
   dataNascimento: string | null;
   profissao: string | null;
-  parentesco: string;
+  parentesco: GrauParentesco;
   responsavelPrincipal: boolean;
   probabilidadeVoto: string;
   telefone: string | null;

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -293,14 +293,16 @@
                 name="parentesco_{{ i }}"
               >
                 <option value="">Selecione o parentesco</option>
-                <option *ngFor="let parentesco of grausParentesco" [value]="parentesco">{{ parentesco }}</option>
+                <option *ngFor="let parentesco of grausParentesco" [value]="parentesco">
+                  {{ descricoesParentesco[parentesco] }}
+                </option>
               </select>
             </div>
 
             <div *ngIf="membro.responsavel">
               <label class="block text-sm font-semibold text-gray-700 mb-2">Grau de Parentesco</label>
               <div class="w-full px-4 py-3 border-2 border-dashed border-purple-300 rounded-xl bg-purple-50 text-purple-700">
-                Responsável pela família
+                {{ descricoesParentesco[parentescoResponsavel] }}
               </div>
             </div>
 
@@ -328,7 +330,7 @@
                   (change)="definirResponsavel(i, $event.target.checked)"
                 />
                 <label [for]="'responsavel_' + i" class="text-sm font-semibold text-gray-700">
-                  Responsável pela família
+                  {{ descricoesParentesco[parentescoResponsavel] }}
                 </label>
               </div>
               <p class="text-xs text-gray-500 mt-2">Somente um membro pode ser o responsável principal por vez.</p>

--- a/frontend/src/app/modules/familias/parentesco.enum.ts
+++ b/frontend/src/app/modules/familias/parentesco.enum.ts
@@ -1,0 +1,33 @@
+export enum GrauParentesco {
+  PAI = 'pai',
+  MAE = 'mae',
+  FILHO_A = 'filho_a',
+  FILHA = 'filha',
+  FILHO = 'filho',
+  IRMAO_A = 'irmao_a',
+  PRIMO_A = 'primo_a',
+  TIO_A = 'tio_a',
+  SOBRINHO_A = 'sobrinho_a',
+  CONJUGE = 'conjuge',
+  AVO_O = 'avo_o',
+  ENTEADO_A = 'enteado_a',
+  RESPONSAVEL = 'responsavel',
+  OUTRO = 'outro'
+}
+
+export const DESCRICOES_PARENTESCO: Record<GrauParentesco, string> = {
+  [GrauParentesco.PAI]: 'Pai',
+  [GrauParentesco.MAE]: 'Mãe',
+  [GrauParentesco.FILHO_A]: 'Filho(a)',
+  [GrauParentesco.FILHA]: 'Filha',
+  [GrauParentesco.FILHO]: 'Filho',
+  [GrauParentesco.IRMAO_A]: 'Irmão(ã)',
+  [GrauParentesco.PRIMO_A]: 'Primo(a)',
+  [GrauParentesco.TIO_A]: 'Tio(a)',
+  [GrauParentesco.SOBRINHO_A]: 'Sobrinho(a)',
+  [GrauParentesco.CONJUGE]: 'Cônjuge',
+  [GrauParentesco.AVO_O]: 'Avô(ó)',
+  [GrauParentesco.ENTEADO_A]: 'Enteado(a)',
+  [GrauParentesco.RESPONSAVEL]: 'Responsável pela família',
+  [GrauParentesco.OUTRO]: 'Outro'
+};


### PR DESCRIPTION
## Summary
- converte o parentesco de membros de família para o enum `Parentesco` na API e persiste os códigos como texto
- atualiza DTOs e cria o enum TypeScript com todas as descrições, incluindo a opção `responsavel`
- adapta a tela de nova família para enviar os códigos do enum e exibir os rótulos correspondentes

## Testing
- npm test (frontend)
- npm test (backend-java) *(falha: projeto Java sem package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9a3488808328b5bcc1974613a487