### PR TITLE
Corrige persistência do parentesco em enum Postgres

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
@@ -18,6 +18,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.type.descriptor.jdbc.PostgreSQLEnumJdbcType;
 
 @Entity
 @Table(name = "membro_familia")
@@ -39,6 +41,7 @@ public class MembroFamilia {
 
   @NotNull
   @Enumerated(EnumType.STRING)
+  @JdbcType(PostgreSQLEnumJdbcType.INSTANCE)
   @Column(name = "parentesco", nullable = false, columnDefinition = "grau_parentesco")
   private Parentesco parentesco;
 

--- a/backend-java/src/main/resources/db/ddl.sql
+++ b/backend-java/src/main/resources/db/ddl.sql
@@ -49,12 +49,29 @@ CREATE TABLE IF NOT EXISTS familia (
   criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+CREATE TYPE IF NOT EXISTS grau_parentesco AS ENUM (
+  'PAI',
+  'MAE',
+  'FILHO_A',
+  'FILHA',
+  'FILHO',
+  'IRMAO_A',
+  'PRIMO_A',
+  'TIO_A',
+  'SOBRINHO_A',
+  'CONJUGE',
+  'AVO_O',
+  'ENTEADO_A',
+  'RESPONSAVEL',
+  'OUTRO'
+);
+
 CREATE TABLE IF NOT EXISTS membro_familia (
   id BIGSERIAL PRIMARY KEY,
   nome_completo VARCHAR(255) NOT NULL,
   data_nascimento DATE,
   profissao VARCHAR(255),
-  parentesco VARCHAR(255) NOT NULL,
+  parentesco grau_parentesco NOT NULL,
   responsavel_principal BOOLEAN NOT NULL DEFAULT FALSE,
   probabilidade_voto VARCHAR(255) NOT NULL,
   telefone VARCHAR(30),


### PR DESCRIPTION
## Resumo
- ajusta o mapeamento do campo `parentesco` para usar o tipo enum do PostgreSQL
- inclui a definição do tipo `grau_parentesco` no script DDL

## Testes
- npm test (backend-java) *(falhou: ausência de package.json)*
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68dca5d0ab988328983e44194b64b477