### PR TITLE
Corrige persistência de parentesco e habilita migrações Flyway

### DIFF
--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -47,6 +47,10 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
@@ -18,8 +18,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import org.hibernate.annotations.JdbcType;
-import org.hibernate.type.descriptor.jdbc.PostgreSQLEnumJdbcType;
 
 @Entity
 @Table(name = "membro_familia")
@@ -41,8 +39,7 @@ public class MembroFamilia {
 
   @NotNull
   @Enumerated(EnumType.STRING)
-  @JdbcType(PostgreSQLEnumJdbcType.INSTANCE)
-  @Column(name = "parentesco", nullable = false, columnDefinition = "grau_parentesco")
+  @Column(name = "parentesco", nullable = false, length = 50)
   private Parentesco parentesco;
 
   @NotNull

--- a/backend-java/src/main/resources/application.properties
+++ b/backend-java/src/main/resources/application.properties
@@ -6,10 +6,13 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:admin}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 
 spring.mvc.problemdetails.enabled=true
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+spring.flyway.locations=classpath:db/migration

--- a/backend-java/src/main/resources/db/migration/V1__criar_estrutura_inicial.sql
+++ b/backend-java/src/main/resources/db/migration/V1__criar_estrutura_inicial.sql
@@ -1,5 +1,4 @@
--- Script de criação das tabelas principais para o módulo de pessoas
-
+-- Criação inicial das tabelas essenciais para o módulo de famílias
 CREATE TABLE IF NOT EXISTS cidades (
   id BIGSERIAL PRIMARY KEY,
   nome VARCHAR(150) NOT NULL,

--- a/backend-java/src/main/resources/db/migration/V2__ajustar_parentesco_para_texto.sql
+++ b/backend-java/src/main/resources/db/migration/V2__ajustar_parentesco_para_texto.sql
@@ -1,0 +1,17 @@
+-- Ajusta a coluna de parentesco para armazenar o valor textual do enum Java
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'membro_familia'
+      AND column_name = 'parentesco'
+      AND udt_name = 'grau_parentesco'
+  ) THEN
+    ALTER TABLE membro_familia
+      ALTER COLUMN parentesco TYPE VARCHAR(50)
+      USING parentesco::TEXT;
+
+    DROP TYPE IF EXISTS grau_parentesco;
+  END IF;
+END $$;


### PR DESCRIPTION
## Resumo
- Ajusta o mapeamento do campo `parentesco` para persistir o valor textual do enum.
- Configura o Flyway e adiciona scripts de criação/alteração da base de dados.
- Atualiza as propriedades da aplicação e o DDL legado para alinhar com a nova abordagem.

## Testes
- `npm test` (frontend)
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68e002a3e9748328bf6ca5cca19331d9