### PR TITLE
Remover coluna CPF remanescente em membro_familia

### DIFF
--- a/backend-java/src/main/resources/db/migration/V3__remover_cpf_de_membro_familia.sql
+++ b/backend-java/src/main/resources/db/migration/V3__remover_cpf_de_membro_familia.sql
@@ -1,0 +1,3 @@
+-- Remove a coluna CPF da tabela membro_familia caso ainda exista
+ALTER TABLE membro_familia
+  DROP COLUMN IF EXISTS cpf;


### PR DESCRIPTION
## Resumo
- adiciona migração para eliminar a coluna cpf remanescente na tabela membro_familia

## Testes
- npm test (backend) *(falhou: package.json ausente)*
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e0052ae2b4832885f9320e5fc2fcb4