### PR TITLE
Implementar notificações visuais para cadastro de família

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,3 +2,4 @@
   <app-top-nav *ngIf="showTopNav"></app-top-nav>
   <router-outlet></router-outlet>
 </div>
+<app-notification></app-notification>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -4,9 +4,10 @@ import { HttpClientModule } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { TopNavComponent } from './components/top-nav/top-nav.component';
+import { NotificationComponent } from './components/notification/notification.component';
 
 @NgModule({
-  declarations: [AppComponent, TopNavComponent],
+  declarations: [AppComponent, TopNavComponent, NotificationComponent],
   imports: [BrowserModule, HttpClientModule, AppRoutingModule],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/components/notification/notification.component.css
+++ b/frontend/src/app/components/notification/notification.component.css
@@ -1,0 +1,114 @@
+:host {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 1050;
+  width: min(22rem, calc(100vw - 2rem));
+  pointer-events: none;
+}
+
+.notification-card {
+  display: flex;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.15);
+  overflow: hidden;
+  animation: fadeIn 0.18s ease-out;
+  pointer-events: auto;
+}
+
+.notification-body {
+  position: relative;
+  display: flex;
+  flex: 1;
+  padding: 1rem 1.25rem;
+  gap: 0.75rem;
+}
+
+.notification-accent {
+  width: 0.35rem;
+  background: var(--accent-color, #3b82f6);
+}
+
+.notification-content {
+  flex: 1;
+}
+
+.notification-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.notification-message {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: #475569;
+  line-height: 1.4;
+  white-space: pre-line;
+}
+
+.notification-close {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.75rem;
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.notification-close:hover {
+  color: #475569;
+}
+
+.notification-success {
+  --accent-color: #16a34a;
+}
+
+.notification-success .notification-title {
+  color: #15803d;
+}
+
+.notification-success .notification-message {
+  color: #166534;
+}
+
+.notification-error {
+  --accent-color: #dc2626;
+}
+
+.notification-error .notification-title {
+  color: #b91c1c;
+}
+
+.notification-error .notification-message {
+  color: #991b1b;
+}
+
+.notification-info {
+  --accent-color: #2563eb;
+}
+
+.notification-info .notification-title {
+  color: #1d4ed8;
+}
+
+.notification-info .notification-message {
+  color: #1e40af;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/frontend/src/app/components/notification/notification.component.html
+++ b/frontend/src/app/components/notification/notification.component.html
@@ -1,0 +1,18 @@
+<div
+  *ngIf="notification$ | async as notification"
+  class="notification-card"
+  [ngClass]="typeClassMap[notification.type]"
+  role="status"
+  aria-live="polite"
+>
+  <div class="notification-accent"></div>
+  <div class="notification-body">
+    <button type="button" class="notification-close" (click)="dismiss()" aria-label="Fechar notificação">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <div class="notification-content">
+      <p class="notification-title">{{ notification.title }}</p>
+      <p *ngIf="notification.message" class="notification-message">{{ notification.message }}</p>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/notification/notification.component.ts
+++ b/frontend/src/app/components/notification/notification.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { NotificationData, NotificationService } from '../../modules/shared/services/notification.service';
+
+@Component({
+  standalone: false,
+  selector: 'app-notification',
+  templateUrl: './notification.component.html',
+  styleUrls: ['./notification.component.css']
+})
+export class NotificationComponent {
+  readonly notification$: Observable<NotificationData | null>;
+
+  readonly typeClassMap: Record<NotificationData['type'], string> = {
+    success: 'notification-success',
+    error: 'notification-error',
+    info: 'notification-info'
+  };
+
+  constructor(private readonly notificationService: NotificationService) {
+    this.notification$ = this.notificationService.notification$;
+  }
+
+  dismiss(): void {
+    this.notificationService.dismiss();
+  }
+}

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -5,6 +5,7 @@ import { DESCRICOES_PARENTESCO, GrauParentesco } from '../parentesco.enum';
 import { Bairro, Cidade, LocalidadesService, Regiao } from '../../shared/services/localidades.service';
 import { ViaCepResponse, ViaCepService } from '../../shared/services/via-cep.service';
 import { AuthService } from '../../shared/services/auth.service';
+import { NotificationService } from '../../shared/services/notification.service';
 
 const VALOR_NOVA_REGIAO = '__nova__';
 const VALOR_NOVO_BAIRRO = '__novo__';
@@ -107,7 +108,8 @@ export class NovaFamiliaComponent implements OnInit {
     private readonly familiasService: FamiliasService,
     private readonly localidadesService: LocalidadesService,
     private readonly viaCepService: ViaCepService,
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly notificationService: NotificationService
   ) {
     this.ehAdministrador = this.authService.ehAdministrador();
     this.membros = [this.criarMembro(true)];
@@ -617,21 +619,28 @@ export class NovaFamiliaComponent implements OnInit {
     this.familiasService.criarFamilia(payload).subscribe({
       next: (resposta: FamiliaResponse | null) => {
         if (!resposta) {
-          window.alert('Não foi possível confirmar o cadastro da família no banco de dados. Tente novamente.');
+          this.notificationService.showError(
+            'Não foi possível confirmar o cadastro da família.',
+            'Tente novamente em instantes.'
+          );
           return;
         }
 
         const responsavel = this.obterResponsavelServidor(resposta) || 'Responsável não informado';
         const totalMembros = resposta.membros.length;
 
-        window.alert(
-          `Família do responsável "${responsavel}" cadastrada com sucesso!\n` + `Membros cadastrados: ${totalMembros}`
+        this.notificationService.showSuccess(
+          'Família cadastrada com sucesso!',
+          `Responsável: ${responsavel}\nMembros cadastrados: ${totalMembros}`
         );
         this.router.navigate(['/familias']);
       },
       error: erro => {
         console.error('Erro ao cadastrar família', erro);
-        window.alert('Não foi possível cadastrar a família. Tente novamente.');
+        this.notificationService.showError(
+          'Não foi possível cadastrar a família.',
+          'Tente novamente.'
+        );
       }
     });
   }

--- a/frontend/src/app/modules/shared/services/notification.service.ts
+++ b/frontend/src/app/modules/shared/services/notification.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+type NotificationType = 'success' | 'error' | 'info';
+
+export interface NotificationData {
+  type: NotificationType;
+  title: string;
+  message?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationService {
+  private readonly notificationSubject = new BehaviorSubject<NotificationData | null>(null);
+  private dismissalTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  get notification$(): Observable<NotificationData | null> {
+    return this.notificationSubject.asObservable();
+  }
+
+  showSuccess(title: string, message?: string, durationMs = 6000): void {
+    this.show({ type: 'success', title, message }, durationMs);
+  }
+
+  showError(title: string, message?: string, durationMs = 6000): void {
+    this.show({ type: 'error', title, message }, durationMs);
+  }
+
+  showInfo(title: string, message?: string, durationMs = 6000): void {
+    this.show({ type: 'info', title, message }, durationMs);
+  }
+
+  dismiss(): void {
+    if (this.dismissalTimeout) {
+      clearTimeout(this.dismissalTimeout);
+      this.dismissalTimeout = null;
+    }
+    this.notificationSubject.next(null);
+  }
+
+  private show(notification: NotificationData, durationMs: number): void {
+    if (this.dismissalTimeout) {
+      clearTimeout(this.dismissalTimeout);
+    }
+
+    this.notificationSubject.next(notification);
+
+    if (durationMs > 0) {
+      this.dismissalTimeout = setTimeout(() => this.dismiss(), durationMs);
+    }
+  }
+}


### PR DESCRIPTION
## Resumo
- criar serviço de notificações e componente visual fixo para manter a identidade da interface
- substituir os `window.alert` do fluxo de cadastro de famílias por notificações do sistema
- registrar o novo componente globalmente para exibir mensagens em toda a aplicação

## Testes
- npm test (frontend)
- npm test (backend-java) *(falha: inexistência de package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e00827bf0c8328ba5686a8d0acd7fe