### PR TITLE
Implementa filtros dinâmicos e paginação na listagem de famílias

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/controller/FamiliaController.java
+++ b/backend-java/src/main/java/com/gestorpolitico/controller/FamiliaController.java
@@ -1,17 +1,22 @@
 package com.gestorpolitico.controller;
 
+import com.gestorpolitico.dto.FamiliaFiltroRequestDTO;
+import com.gestorpolitico.dto.FamiliaListaResponseDTO;
 import com.gestorpolitico.dto.FamiliaRequestDTO;
 import com.gestorpolitico.dto.FamiliaResponseDTO;
 import com.gestorpolitico.service.FamiliaService;
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @RestController
 @RequestMapping("/api/familias")
@@ -29,8 +34,15 @@ public class FamiliaController {
   }
 
   @GetMapping
-  public ResponseEntity<List<FamiliaResponseDTO>> listarFamilias() {
-    List<FamiliaResponseDTO> familias = familiaService.listarFamilias();
+  public ResponseEntity<FamiliaListaResponseDTO> listarFamilias(
+    FamiliaFiltroRequestDTO filtro,
+    @RequestParam(defaultValue = "0") int pagina,
+    @RequestParam(defaultValue = "20") int tamanho
+  ) {
+    int paginaAjustada = Math.max(pagina, 0);
+    int tamanhoAjustado = Math.min(Math.max(tamanho, 1), 200);
+    Pageable pageable = PageRequest.of(paginaAjustada, tamanhoAjustado, Sort.by(Sort.Direction.DESC, "criadoEm"));
+    FamiliaListaResponseDTO familias = familiaService.buscarFamilias(filtro, pageable);
     return ResponseEntity.ok(familias);
   }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaFiltroRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaFiltroRequestDTO.java
@@ -1,0 +1,110 @@
+package com.gestorpolitico.dto;
+
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public class FamiliaFiltroRequestDTO {
+  private Long cidadeId;
+  private String regiao;
+  private String bairro;
+  private String responsavel;
+  private String probabilidadeVoto;
+  private String rua;
+  private String numero;
+  private String cep;
+  private String termo;
+
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private LocalDate dataInicio;
+
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private LocalDate dataFim;
+
+  public Long getCidadeId() {
+    return cidadeId;
+  }
+
+  public void setCidadeId(Long cidadeId) {
+    this.cidadeId = cidadeId;
+  }
+
+  public String getRegiao() {
+    return regiao;
+  }
+
+  public void setRegiao(String regiao) {
+    this.regiao = regiao;
+  }
+
+  public String getBairro() {
+    return bairro;
+  }
+
+  public void setBairro(String bairro) {
+    this.bairro = bairro;
+  }
+
+  public String getResponsavel() {
+    return responsavel;
+  }
+
+  public void setResponsavel(String responsavel) {
+    this.responsavel = responsavel;
+  }
+
+  public String getProbabilidadeVoto() {
+    return probabilidadeVoto;
+  }
+
+  public void setProbabilidadeVoto(String probabilidadeVoto) {
+    this.probabilidadeVoto = probabilidadeVoto;
+  }
+
+  public String getRua() {
+    return rua;
+  }
+
+  public void setRua(String rua) {
+    this.rua = rua;
+  }
+
+  public String getNumero() {
+    return numero;
+  }
+
+  public void setNumero(String numero) {
+    this.numero = numero;
+  }
+
+  public String getCep() {
+    return cep;
+  }
+
+  public void setCep(String cep) {
+    this.cep = cep;
+  }
+
+  public String getTermo() {
+    return termo;
+  }
+
+  public void setTermo(String termo) {
+    this.termo = termo;
+  }
+
+  public LocalDate getDataInicio() {
+    return dataInicio;
+  }
+
+  public void setDataInicio(LocalDate dataInicio) {
+    this.dataInicio = dataInicio;
+  }
+
+  public LocalDate getDataFim() {
+    return dataFim;
+  }
+
+  public void setDataFim(LocalDate dataFim) {
+    this.dataFim = dataFim;
+  }
+}

--- a/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaListaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaListaResponseDTO.java
@@ -1,0 +1,81 @@
+package com.gestorpolitico.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FamiliaListaResponseDTO {
+  private List<FamiliaResponseDTO> familias = new ArrayList<>();
+  private long total;
+  private int pagina;
+  private int tamanho;
+  private long responsaveisAtivos;
+  private long novosCadastros;
+
+  public FamiliaListaResponseDTO() {}
+
+  public FamiliaListaResponseDTO(
+    List<FamiliaResponseDTO> familias,
+    long total,
+    int pagina,
+    int tamanho,
+    long responsaveisAtivos,
+    long novosCadastros
+  ) {
+    if (familias != null) {
+      this.familias = familias;
+    }
+    this.total = total;
+    this.pagina = pagina;
+    this.tamanho = tamanho;
+    this.responsaveisAtivos = responsaveisAtivos;
+    this.novosCadastros = novosCadastros;
+  }
+
+  public List<FamiliaResponseDTO> getFamilias() {
+    return familias;
+  }
+
+  public void setFamilias(List<FamiliaResponseDTO> familias) {
+    this.familias = familias;
+  }
+
+  public long getTotal() {
+    return total;
+  }
+
+  public void setTotal(long total) {
+    this.total = total;
+  }
+
+  public int getPagina() {
+    return pagina;
+  }
+
+  public void setPagina(int pagina) {
+    this.pagina = pagina;
+  }
+
+  public int getTamanho() {
+    return tamanho;
+  }
+
+  public void setTamanho(int tamanho) {
+    this.tamanho = tamanho;
+  }
+
+  public long getResponsaveisAtivos() {
+    return responsaveisAtivos;
+  }
+
+  public void setResponsaveisAtivos(long responsaveisAtivos) {
+    this.responsaveisAtivos = responsaveisAtivos;
+  }
+
+  public long getNovosCadastros() {
+    return novosCadastros;
+  }
+
+  public void setNovosCadastros(long novosCadastros) {
+    this.novosCadastros = novosCadastros;
+  }
+}

--- a/backend-java/src/main/java/com/gestorpolitico/repository/FamiliaRepository.java
+++ b/backend-java/src/main/java/com/gestorpolitico/repository/FamiliaRepository.java
@@ -5,8 +5,9 @@ import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface FamiliaRepository extends JpaRepository<Familia, Long> {
+public interface FamiliaRepository extends JpaRepository<Familia, Long>, JpaSpecificationExecutor<Familia> {
   @EntityGraph(attributePaths = "membros")
   List<Familia> findAllByOrderByCriadoEmDesc();
 

--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -49,95 +49,287 @@
             <div class="text-sm text-gray-500">Listagem com filtros inteligentes</div>
           </div>
         </div>
-        <div class="flex flex-wrap items-center gap-2">
-          <button
-            *ngFor="let filtro of filtros; let i = index"
-            class="px-4 py-2 rounded-full text-sm font-medium transition-all"
-            [ngClass]="{
-              'bg-blue-50 text-blue-600 shadow-inner': i === 0,
-              'bg-gray-50 text-gray-500 hover:bg-blue-50 hover:text-blue-600': i !== 0
-            }"
-          >
-            {{ filtro }}
-          </button>
+        <div class="flex items-center gap-6 text-sm text-gray-600">
+          <div>
+            <div class="text-lg font-semibold text-gray-900">{{ totalFamilias }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wide">registros encontrados</div>
+          </div>
+          <div>
+            <div class="text-lg font-semibold text-gray-900">{{ responsaveisAtivos }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wide">responsáveis ativos</div>
+          </div>
+          <div>
+            <div class="text-lg font-semibold text-gray-900">{{ novosCadastros }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wide">novos na semana</div>
+          </div>
         </div>
       </div>
 
-      <div class="p-6 bg-gray-50">
-        <div *ngIf="carregando" class="text-center py-10 text-gray-500">Carregando famílias cadastradas...</div>
+      <div class="px-6 py-6 border-b border-gray-100 bg-gray-50">
+        <form
+          [formGroup]="filtroForm"
+          (ngSubmit)="aplicarFiltros()"
+          class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4"
+          autocomplete="off"
+        >
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Cidade</label>
+            <select
+              formControlName="cidadeId"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              (change)="onCidadeChange($event.target.value)"
+            >
+              <option [ngValue]="null">Todas as cidades</option>
+              <option *ngFor="let cidade of cidades" [ngValue]="cidade.id">{{ cidade.nome }} / {{ cidade.uf }}</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Região</label>
+            <select
+              formControlName="regiao"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todas as regiões</option>
+              <option *ngFor="let regiao of regioes" [value]="regiao.nome">{{ regiao.nome }}</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Busca livre</label>
+            <input
+              type="text"
+              formControlName="termo"
+              placeholder="Digite nome, endereço ou palavra-chave"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Responsável</label>
+            <input
+              type="text"
+              formControlName="responsavel"
+              placeholder="Nome do responsável"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Probabilidade de voto</label>
+            <select
+              formControlName="probabilidadeVoto"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todas</option>
+              <option *ngFor="let probabilidade of probabilidadesVoto" [value]="probabilidade">{{ probabilidade }}</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Data inicial</label>
+            <input
+              type="date"
+              formControlName="dataInicio"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Data final</label>
+            <input
+              type="date"
+              formControlName="dataFim"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Bairro</label>
+            <input
+              type="text"
+              formControlName="bairro"
+              placeholder="Nome do bairro"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Rua</label>
+            <input
+              type="text"
+              formControlName="rua"
+              placeholder="Logradouro"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Número</label>
+            <input
+              type="text"
+              formControlName="numero"
+              placeholder="Número"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">CEP</label>
+            <input
+              type="text"
+              formControlName="cep"
+              placeholder="Somente números"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex items-end justify-end gap-3 md:col-span-2 xl:col-span-4">
+            <button
+              type="button"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-white transition-all"
+              (click)="limparFiltros()"
+            >
+              Limpar filtros
+            </button>
+            <button
+              type="submit"
+              class="px-5 py-2.5 rounded-xl gradient-blue text-white text-sm font-semibold shadow-md hover:opacity-90 transition-all"
+            >
+              Aplicar filtros
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div class="px-6 py-5">
+        <div *ngIf="carregando" class="text-center py-10 text-gray-500 text-sm">
+          Carregando famílias cadastradas...
+        </div>
 
         <div *ngIf="erroCarregamento" class="text-center py-10 text-red-500 font-semibold">
           {{ erroCarregamento }}
         </div>
 
-        <div
-          *ngIf="!carregando && !erroCarregamento && familias.length === 0"
-          class="text-center py-10 text-gray-500"
-        >
-          Nenhuma família cadastrada até o momento.
-        </div>
+        <div *ngIf="!carregando && !erroCarregamento" class="space-y-6">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div class="text-sm text-gray-600">
+              <ng-container *ngIf="totalFamilias > 0; else nenhumaFamilia">
+                Mostrando <span class="font-semibold text-gray-900">{{ inicioIntervalo }}</span>
+                -
+                <span class="font-semibold text-gray-900">{{ fimIntervalo }}</span>
+                de
+                <span class="font-semibold text-gray-900">{{ totalFamilias }}</span>
+                famílias cadastradas
+              </ng-container>
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-500 uppercase tracking-wide">Por página</label>
+              <select
+                class="px-3 py-2 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                [value]="tamanhoPagina"
+                (change)="alterarTamanhoPagina($event)"
+              >
+                <option *ngFor="let tamanho of tamanhosPagina" [value]="tamanho">{{ tamanho }}</option>
+              </select>
+            </div>
+          </div>
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4" *ngIf="familias.length > 0">
-          <div
-            *ngFor="let familia of familias"
-            class="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm hover:shadow-md transition-all"
-            [ngClass]="{ 'border-2 border-emerald-400 shadow-xl': familia.id === familiaSelecionadaId }"
-          >
-            <div class="flex items-start justify-between">
-              <div>
-                <h2 class="text-lg font-semibold text-gray-900 mb-1">Família de {{ obterResponsavel(familia) }}</h2>
-                <p class="text-sm text-gray-500">
-                  {{ familia.bairro }} • {{ dataCadastro(familia) || 'Data não disponível' }}
-                </p>
-              </div>
-              <span class="px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold">
-                {{ obterTotalMembros(familia) }} membros
-              </span>
-            </div>
-            <div class="mt-4 grid grid-cols-3 gap-4 text-center">
-              <div>
-                <div class="text-2xl font-bold text-gray-900">{{ obterTotalMembros(familia) }}</div>
-                <div class="text-xs text-gray-500">Integrantes</div>
-              </div>
-              <div>
-                <div class="text-2xl font-bold text-gray-900">
-                  {{ contarMembrosPorProbabilidade(familia, 'Alta') }}
-                </div>
-                <div class="text-xs text-gray-500">Alta probabilidade</div>
-              </div>
-              <div>
-                <div class="text-2xl font-bold text-gray-900">
-                  {{ contarMembrosPorProbabilidade(familia, 'Baixa') }}
-                </div>
-                <div class="text-xs text-gray-500">Baixa probabilidade</div>
-              </div>
-            </div>
-            <div class="mt-5 flex items-center justify-between">
-              <div class="flex -space-x-2">
-                <ng-container *ngFor="let membro of membrosSecundarios(familia) | slice:0:2">
-                  <div
-                    class="w-8 h-8 rounded-full bg-blue-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-blue-600"
-                    [ngClass]="{
-                      'bg-purple-100 text-purple-600': membro.probabilidadeVoto === 'Alta',
-                      'bg-amber-100 text-amber-600': membro.probabilidadeVoto === 'Média',
-                      'bg-gray-100 text-gray-600': membro.probabilidadeVoto === 'Baixa'
-                    }"
-                    [title]="membro.nomeCompleto"
-                  >
-                    {{ obterIniciais(membro.nomeCompleto) }}
-                  </div>
-                </ng-container>
+          <div class="bg-white border border-gray-200 rounded-3xl shadow-sm">
+            <ng-container *ngIf="familias.length > 0; else listaVazia">
+              <div class="max-h-[520px] overflow-y-auto divide-y divide-gray-100">
                 <div
-                  *ngIf="membrosSecundarios(familia).length > 2"
-                  class="w-8 h-8 rounded-full bg-gray-100 border-2 border-white flex items-center justify-center text-xs font-semibold text-gray-500"
+                  *ngFor="let familia of familias"
+                  class="p-6 transition-colors"
+                  [ngClass]="{
+                    'bg-blue-50/60 border-l-4 border-blue-400': familia.id === familiaSelecionadaId,
+                    'hover:bg-gray-50': familia.id !== familiaSelecionadaId
+                  }"
                 >
-                  +{{ membrosSecundarios(familia).length - 2 }}
+                  <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+                    <div class="flex items-start gap-4">
+                      <div class="w-12 h-12 rounded-2xl bg-blue-100 text-blue-600 flex items-center justify-center font-semibold text-lg">
+                        {{ obterIniciais(obterResponsavel(familia)) }}
+                      </div>
+                      <div>
+                        <h2 class="text-lg font-semibold text-gray-900 mb-1">
+                          Família de {{ obterResponsavel(familia) }}
+                        </h2>
+                        <div class="text-sm text-gray-500 flex flex-wrap items-center gap-2">
+                          <span *ngIf="familia.enderecoDetalhado?.bairro">{{ familia.enderecoDetalhado.bairro }}</span>
+                          <span *ngIf="familia.enderecoDetalhado?.regiao">• Região {{ familia.enderecoDetalhado.regiao }}</span>
+                          <span>• {{ dataCadastro(familia) || 'Data não disponível' }}</span>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="text-sm text-gray-500 text-left lg:text-right">
+                      <div class="font-semibold text-gray-700">Contato do responsável</div>
+                      <div>{{ obterTelefoneResponsavel(familia) }}</div>
+                    </div>
+                  </div>
+
+                  <div class="mt-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+                    <div class="flex items-center gap-3">
+                      <div class="text-2xl font-bold text-gray-900">{{ obterTotalMembros(familia) }}</div>
+                      <div class="text-xs text-gray-500 uppercase tracking-wide">Integrantes</div>
+                    </div>
+                    <div class="flex items-center gap-3">
+                      <div class="text-2xl font-bold text-emerald-600">
+                        {{ contarMembrosPorProbabilidade(familia, 'Alta') }}
+                      </div>
+                      <div class="text-xs text-emerald-600 uppercase tracking-wide">Alta probabilidade</div>
+                    </div>
+                    <div class="flex items-center gap-3">
+                      <div class="text-2xl font-bold text-amber-500">
+                        {{ contarMembrosPorProbabilidade(familia, 'Média') }}
+                      </div>
+                      <div class="text-xs text-amber-500 uppercase tracking-wide">Média probabilidade</div>
+                    </div>
+                    <div class="flex items-center gap-3">
+                      <div class="text-2xl font-bold text-gray-600">
+                        {{ contarMembrosPorProbabilidade(familia, 'Baixa') }}
+                      </div>
+                      <div class="text-xs text-gray-500 uppercase tracking-wide">Baixa probabilidade</div>
+                    </div>
+                  </div>
+
+                  <div class="mt-5 text-xs text-gray-500 flex flex-wrap gap-3">
+                    <span *ngIf="familia.enderecoDetalhado?.rua">
+                      {{ familia.enderecoDetalhado.rua }}, {{ familia.enderecoDetalhado?.numero || 's/ nº' }}
+                    </span>
+                    <span *ngIf="familia.enderecoDetalhado?.cep">CEP {{ familia.enderecoDetalhado.cep }}</span>
+                    <span *ngIf="familia.enderecoDetalhado">
+                      {{ familia.enderecoDetalhado.cidade }}/{{ familia.enderecoDetalhado.uf }}
+                    </span>
+                  </div>
                 </div>
               </div>
-              <div class="text-sm text-gray-500 text-right">
-                <div class="font-semibold text-gray-700">Contato do responsável</div>
-                <div>{{ obterTelefoneResponsavel(familia) }}</div>
-              </div>
+            </ng-container>
+          </div>
+
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div class="text-sm text-gray-600" *ngIf="totalFamilias > 0">
+              Página <span class="font-semibold text-gray-900">{{ paginaAtual + 1 }}</span>
+              de
+              <span class="font-semibold text-gray-900">{{ totalPaginas }}</span>
+            </div>
+            <div class="flex items-center gap-3">
+              <button
+                type="button"
+                class="px-4 py-2 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-white transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                (click)="alterarPagina(-1)"
+                [disabled]="paginaAtual === 0 || totalFamilias === 0"
+              >
+                ← Anterior
+              </button>
+              <button
+                type="button"
+                class="px-4 py-2 rounded-xl gradient-blue text-white text-sm font-semibold shadow-md hover:opacity-90 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                (click)="alterarPagina(1)"
+                [disabled]="paginaAtual >= totalPaginas - 1 || totalFamilias === 0"
+              >
+                Próxima →
+              </button>
             </div>
           </div>
         </div>
@@ -145,3 +337,13 @@
     </div>
   </div>
 </div>
+
+<ng-template #nenhumaFamilia>
+  <span>Nenhuma família encontrada com os filtros selecionados.</span>
+</ng-template>
+
+<ng-template #listaVazia>
+  <div class="py-16 text-center text-sm text-gray-500">
+    Nenhuma família encontrada com os filtros aplicados.
+  </div>
+</ng-template>

--- a/frontend/src/app/modules/familias/familias.module.ts
+++ b/frontend/src/app/modules/familias/familias.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { FamiliasComponent } from './familias.component';
 import { NovaFamiliaComponent } from './nova-familia/nova-familia.component';
@@ -12,6 +12,6 @@ const routes: Routes = [
 
 @NgModule({
   declarations: [FamiliasComponent, NovaFamiliaComponent],
-  imports: [CommonModule, FormsModule, RouterModule.forChild(routes)]
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule.forChild(routes)]
 })
 export class FamiliasModule {}

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -55,7 +55,7 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   private carregarFamilias(): void {
     this.carregando = true;
     this.erroCarregamento = '';
-    this.assinaturaFamilias = this.familiasService.listarFamilias().subscribe({
+    this.assinaturaFamilias = this.familiasService.listarTodasFamilias().subscribe({
       next: familias => {
         this.familiasLocalizadas = familias
           .map(familia => this.converterFamilia(familia))


### PR DESCRIPTION
## Resumo
- adiciona DTOs de filtro e resposta paginada para famílias e expõe o novo endpoint com suporte a filtros, paginação e indicadores
- aplica filtragem dinâmica na consulta de famílias, incluindo pesquisa por responsável, endereço, datas e probabilidade de voto
- atualiza o frontend para consumir a busca paginada, oferecer formulário completo de filtros, paginação com seleção de tamanho e integração com o mapa

## Testes
- `npm test` (backend-java) *(falhou: package.json inexistente no projeto Java)*
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68e0097c19ec8328a64f3cfec24156df