### PR TITLE
Corrige filtros de famílias e adiciona feedback no cadastro

### DIFF
--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -124,7 +124,9 @@
                 class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 <option value="">Todas as regiões</option>
-                <option *ngFor="let regiao of regioes" [value]="regiao.nome">{{ regiao.nome }}</option>
+                <option *ngFor="let regiao of regioes" [value]="regiao.nome">
+                  {{ regiao.nome }}{{ cidadeSelecionadaId === null && regiao.cidadeNome ? ' • ' + regiao.cidadeNome : '' }}
+                </option>
               </select>
             </div>
 

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -366,11 +366,34 @@
       <button
         type="button"
         (click)="cadastrarFamilia()"
-        class="px-8 py-3 gradient-blue text-white rounded-xl font-semibold hover:opacity-90 transition-all duration-200 transform hover:scale-105"
+        [disabled]="salvandoFamilia"
+        class="px-8 py-3 gradient-blue text-white rounded-xl font-semibold hover:opacity-90 transition-all duration-200 transform hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed"
       >
-        Cadastrar Família
+        {{ salvandoFamilia ? 'Salvando...' : 'Cadastrar Família' }}
       </button>
     </div>
+  </div>
+</div>
+
+<div
+  *ngIf="salvandoFamilia"
+  class="fixed inset-0 bg-white/70 backdrop-blur-sm flex items-center justify-center z-[60]"
+>
+  <div class="bg-white rounded-2xl shadow-xl border border-gray-200 px-6 py-5 flex items-center gap-3 text-gray-700">
+    <svg
+      class="w-6 h-6 text-blue-600 animate-spin"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+      <path
+        class="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      ></path>
+    </svg>
+    <span class="font-semibold">Salvando família...</span>
   </div>
 </div>
 

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -102,6 +102,7 @@ export class NovaFamiliaComponent implements OnInit {
 
   mostrarPrevia = false;
   previaFamilia: PreviaFamilia | null = null;
+  salvandoFamilia = false;
 
   constructor(
     private readonly router: Router,
@@ -611,10 +612,15 @@ export class NovaFamiliaComponent implements OnInit {
   }
 
   cadastrarFamilia(): void {
+    if (this.salvandoFamilia) {
+      return;
+    }
+
     if (!this.formularioValido()) {
       return;
     }
 
+    this.salvandoFamilia = true;
     const payload = this.montarPayload();
     this.familiasService.criarFamilia(payload).subscribe({
       next: (resposta: FamiliaResponse | null) => {
@@ -623,6 +629,7 @@ export class NovaFamiliaComponent implements OnInit {
             'Não foi possível confirmar o cadastro da família.',
             'Tente novamente em instantes.'
           );
+          this.salvandoFamilia = false;
           return;
         }
 
@@ -633,6 +640,7 @@ export class NovaFamiliaComponent implements OnInit {
           'Família cadastrada com sucesso!',
           `Responsável: ${responsavel}\nMembros cadastrados: ${totalMembros}`
         );
+        this.salvandoFamilia = false;
         this.router.navigate(['/familias']);
       },
       error: erro => {
@@ -641,6 +649,7 @@ export class NovaFamiliaComponent implements OnInit {
           'Não foi possível cadastrar a família.',
           'Tente novamente.'
         );
+        this.salvandoFamilia = false;
       }
     });
   }


### PR DESCRIPTION
## Resumo
- Ajusta o carregamento inicial da listagem de famílias para exibir todos os registros sem filtros aplicados.
- Pré-carrega as regiões cadastradas por cidade e mostra o nome da cidade na lista quando nenhuma cidade está filtrada.
- Adiciona feedback visual de salvamento no formulário de nova família com botão desabilitado e overlay de carregamento.

## Testes
- npm test (frontend)
- npm test (backend-java) *(falha: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68e023f6e8e08328b84bb65c70b2a634