### PR TITLE
Corrige erros de compilação no GeocodingService

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/service/GeocodingService.java
+++ b/backend-java/src/main/java/com/gestorpolitico/service/GeocodingService.java
@@ -75,48 +75,7 @@ public class GeocodingService {
     }
   }
 
-    return webClient
-      .get()
-      .uri(
-        UriComponentsBuilder
-          .fromHttpUrl(NOMINATIM_URL)
-          .queryParam("q", UriUtils.encode(enderecoCompleto, StandardCharsets.UTF_8))
-          .queryParam("format", "json")
-          .queryParam("limit", "1")
-          .queryParam("addressdetails", "0")
-          .queryParam("countrycodes", "br")
-          .build(true)
-          .toUri()
-      )
-      .retrieve()
-      .bodyToMono(NominatimResponse[].class)
-      .doOnError(throwable -> LOGGER.warn("Falha ao consultar Nominatim: {}", throwable.getMessage()))
-      .onErrorReturn(new NominatimResponse[0])
-      .flatMap(respostas -> {
-        if (respostas.length == 0) {
-          if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Nominatim não retornou resultados para: {}", enderecoCompleto);
-          }
-          return Mono.empty();
-        }
-        Coordenada coordenada = respostas[0].toCoordenada();
-        if (coordenada == null) {
-          LOGGER.debug("Primeiro resultado do Nominatim não possui coordenadas válidas");
-          return Mono.empty();
-        }
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug(
-            "Nominatim retornou latitude {} e longitude {}",
-            coordenada.latitude(),
-            coordenada.longitude()
-          );
-        }
-        return Mono.just(coordenada);
-      })
-      .blockOptional();
-  }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class NominatimResponse {
     @JsonProperty("lat")
     private String latitude;


### PR DESCRIPTION
## Summary
- remove a implementação reativa duplicada que estava fora do método e quebrava a compilação
- mantém apenas a lógica bloqueante com Optional para retorno seguro e ajustes de formatação

## Testing
- npm test (frontend)
- npm test (backend) *(não executado: diretório inexistente)*

------
https://chatgpt.com/codex/tasks/task_e_68e086055ac483289f9e8a9d0e8c58eb