### PR TITLE
Ajusta integração com Nominatim e adiciona testes

### DIFF
--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -55,6 +55,12 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>4.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/backend-java/src/main/java/com/gestorpolitico/config/HttpClientConfig.java
+++ b/backend-java/src/main/java/com/gestorpolitico/config/HttpClientConfig.java
@@ -16,7 +16,7 @@ public class HttpClientConfig {
     return builder
       .clone()
       .exchangeStrategies(strategies)
-      .defaultHeader("User-Agent", "GestorPolitico/1.0 (+https://github.com/gestorpolitico)")
+      .defaultHeader("User-Agent", "gestor-politico/1.0 (+https://github.com/gestorpolitico)")
       .build();
   }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/service/GeocodingService.java
+++ b/backend-java/src/main/java/com/gestorpolitico/service/GeocodingService.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -16,16 +17,20 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Service
 public class GeocodingService {
   private static final Logger LOGGER = LoggerFactory.getLogger(GeocodingService.class);
-  private static final String NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
-  private static final String USER_AGENT = "GestorPolitico/1.0 (contato@gestorpolitico.com)";
+  private static final String USER_AGENT = "gestor-politico/1.0 (contato@gestorpolitico.com)";
   private static final Duration NOMINATIM_RATE_LIMIT = Duration.ofSeconds(1);
 
   private final WebClient webClient;
+  private final String nominatimUrl;
   private final Object rateLimitLock = new Object();
   private Instant lastRequestTime = Instant.EPOCH;
 
-  public GeocodingService(WebClient webClient) {
+  public GeocodingService(
+    WebClient webClient,
+    @Value("${geocoding.nominatim.url:https://nominatim.openstreetmap.org/search}") String nominatimUrl
+  ) {
     this.webClient = webClient;
+    this.nominatimUrl = nominatimUrl;
   }
 
   public Optional<Coordenada> buscarCoordenadas(String enderecoCompleto) {
@@ -36,7 +41,7 @@ public class GeocodingService {
     LOGGER.info("Consultando Nominatim com endereço: {}", enderecoCompleto);
 
     URI uri = UriComponentsBuilder
-      .fromHttpUrl(NOMINATIM_URL)
+      .fromHttpUrl(nominatimUrl)
       .queryParam("q", enderecoCompleto)
       .queryParam("format", "json")
       .queryParam("limit", "1")

--- a/backend-java/src/test/java/com/gestorpolitico/service/GeocodingServiceTest.java
+++ b/backend-java/src/test/java/com/gestorpolitico/service/GeocodingServiceTest.java
@@ -1,0 +1,77 @@
+package com.gestorpolitico.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Optional;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class GeocodingServiceTest {
+  private MockWebServer mockWebServer;
+  private GeocodingService geocodingService;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    mockWebServer = new MockWebServer();
+    mockWebServer.start();
+    WebClient webClient = WebClient.builder().build();
+    geocodingService = new GeocodingService(webClient, mockWebServer.url("/search").toString());
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  void deveEnviarRequisicaoNoPadraoEsperadoEConverterResposta() throws InterruptedException {
+    mockWebServer.enqueue(
+      new MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/json")
+        .setBody("[{\"lat\":\"-18.9365314\",\"lon\":\"-48.2884139\"}]")
+    );
+
+    Optional<GeocodingService.Coordenada> coordenada = geocodingService.buscarCoordenadas(
+      "Rua Arpoador 147 Uberlandia Minas Gerais Brasil"
+    );
+
+    RecordedRequest recordedRequest = mockWebServer.takeRequest();
+
+    HttpUrl requestUrl = recordedRequest.getRequestUrl();
+
+    assertEquals("/search", requestUrl.encodedPath());
+    assertEquals("Rua Arpoador 147 Uberlandia Minas Gerais Brasil", requestUrl.queryParameter("q"));
+    assertEquals("json", requestUrl.queryParameter("format"));
+    assertEquals("1", requestUrl.queryParameter("limit"));
+    assertEquals("0", requestUrl.queryParameter("addressdetails"));
+    assertEquals("br", requestUrl.queryParameter("countrycodes"));
+    assertEquals("gestor-politico/1.0 (contato@gestorpolitico.com)", recordedRequest.getHeader("User-Agent"));
+    assertEquals("pt-BR", recordedRequest.getHeader("Accept-Language"));
+
+    assertTrue(coordenada.isPresent());
+    assertEquals(-18.9365314, coordenada.get().latitude());
+    assertEquals(-48.2884139, coordenada.get().longitude());
+  }
+
+  @Test
+  void deveRetornarVazioQuandoNaoHaResultados() throws InterruptedException {
+    mockWebServer.enqueue(
+      new MockResponse().setResponseCode(200).setHeader("Content-Type", "application/json").setBody("[]")
+    );
+
+    Optional<GeocodingService.Coordenada> coordenada = geocodingService.buscarCoordenadas("Endereco Inexistente");
+
+    mockWebServer.takeRequest();
+
+    assertTrue(coordenada.isEmpty());
+  }
+}


### PR DESCRIPTION
## Resumo
- ajusta o identificador User-Agent utilizado pelo WebClient e permite configurar a URL do Nominatim por propriedade
- adiciona dependência de MockWebServer e testes unitários garantindo o formato da requisição e o tratamento das coordenadas retornadas

## Testes
- mvn -f backend-java/pom.xml test
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e099ee171c83288316d3b623ec7a51