### PR TITLE
Destacar marcador de famílias no mapa

### DIFF
--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
@@ -44,19 +44,58 @@
 }
 
 .familia-marker {
+  position: relative;
+  width: 48px;
+  height: 48px;
+}
+
+.familia-marker__pulse {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 48px;
+  height: 48px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: rgba(16, 185, 129, 0.18);
+  box-shadow: 0 0 0 6px rgba(16, 185, 129, 0.1);
+  animation: familia-marker-pulse 2s ease-out infinite;
+  pointer-events: none;
+}
+
+.familia-marker__icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
   justify-content: center;
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #10b981, #047857);
+  background: linear-gradient(135deg, #0ea5e9, #2563eb);
   color: #fff;
   border: 3px solid #fff;
-  box-shadow: 0 10px 15px -3px rgba(4, 120, 87, 0.35);
+  box-shadow: 0 12px 24px -6px rgba(37, 99, 235, 0.4);
 }
 
-.familia-marker .fa-solid {
-  font-size: 1rem;
-  filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.35));
+.familia-marker__icon .fa-solid {
+  font-size: 1.1rem;
+  filter: drop-shadow(0 3px 6px rgba(15, 23, 42, 0.35));
+}
+
+@keyframes familia-marker-pulse {
+  0% {
+    opacity: 0.6;
+    transform: translate(-50%, -50%) scale(0.85);
+  }
+  70% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.35);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.85);
+  }
 }

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -26,11 +26,16 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   private camadaMarcadores: L.LayerGroup | null = null;
   private assinaturaFamilias: Subscription | null = null;
   private readonly iconeFamilia = L.divIcon({
-    html: '<i class="fa-solid fa-people-roof" aria-hidden="true"></i>',
+    html: `
+      <div class="familia-marker__pulse" aria-hidden="true"></div>
+      <div class="familia-marker__icon" aria-hidden="true">
+        <i class="fa-solid fa-people-roof"></i>
+      </div>
+    `,
     className: 'familia-marker',
-    iconSize: [36, 36],
-    iconAnchor: [18, 36],
-    popupAnchor: [0, -28]
+    iconSize: [48, 48],
+    iconAnchor: [24, 48],
+    popupAnchor: [0, -36]
   });
 
   constructor(private readonly familiasService: FamiliasService, private readonly router: Router) {}


### PR DESCRIPTION
## Resumo
- atualizar o ícone de famílias do georreferenciamento para incluir camada pulsante e âncoras maiores
- ajustar os estilos do marcador para reforçar o destaque visual com novo gradiente e animação

## Testes
- npm test -- --watch=false (frontend)
- npm test -- --watch=false (backend-java) *(falha: diretório não possui package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e09fa0e3688328af0a66b66b82b444