### PR TITLE
Atualizar ícone de família no mapa

### DIFF
--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
@@ -47,16 +47,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #10b981, #047857);
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
   color: #fff;
-  border: 3px solid #fff;
-  box-shadow: 0 10px 15px -3px rgba(4, 120, 87, 0.35);
+  border: 3px solid rgba(255, 255, 255, 0.95);
+  box-shadow: 0 12px 20px -6px rgba(37, 99, 235, 0.45);
 }
 
 .familia-marker .fa-solid {
-  font-size: 1rem;
+  font-size: 1.1rem;
   filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.35));
 }

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -26,11 +26,11 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   private camadaMarcadores: L.LayerGroup | null = null;
   private assinaturaFamilias: Subscription | null = null;
   private readonly iconeFamilia = L.divIcon({
-    html: '<i class="fa-solid fa-people-roof" aria-hidden="true"></i>',
+    html: '<i class="fa-solid fa-house-chimney-window" aria-hidden="true"></i>',
     className: 'familia-marker',
-    iconSize: [36, 36],
-    iconAnchor: [18, 36],
-    popupAnchor: [0, -28]
+    iconSize: [40, 40],
+    iconAnchor: [20, 40],
+    popupAnchor: [0, -32]
   });
 
   constructor(private readonly familiasService: FamiliasService, private readonly router: Router) {}


### PR DESCRIPTION
## Resumo
- substituir o marcador pulsante por um ícone Font Awesome de casa para famílias no mapa
- ajustar dimensões e estilos do marcador para manter o destaque sem afetar a interação do mapa

## Testes
- npm test -- --watch=false (frontend)
- npm test -- --watch=false (backend-java) *(falha: diretório não possui package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e09fa0e3688328af0a66b66b82b444