### PR TITLE
Adiciona máscara ao campo de CEP no cadastro de famílias

### DIFF
--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -66,9 +66,12 @@
               <input
                 type="text"
                 class="w-full md:flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
-                [(ngModel)]="enderecoFamilia.cep"
+                [ngModel]="enderecoFamilia.cep"
+                (ngModelChange)="aoAlterarCepFamilia($event)"
                 name="cepFamilia"
                 placeholder="00000-000"
+                maxlength="9"
+                autocomplete="postal-code"
               />
               <div class="flex items-center space-x-2">
                 <button

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -182,6 +182,24 @@ export class NovaFamiliaComponent implements OnInit {
     }
   }
 
+  aoAlterarCepFamilia(valor: string): void {
+    if (typeof valor !== 'string') {
+      this.enderecoFamilia.cep = '';
+      return;
+    }
+
+    const apenasDigitos = valor.replace(/\D/g, '').slice(0, 8);
+
+    if (apenasDigitos.length <= 5) {
+      this.enderecoFamilia.cep = apenasDigitos;
+      return;
+    }
+
+    const prefixo = apenasDigitos.slice(0, 5);
+    const sufixo = apenasDigitos.slice(5);
+    this.enderecoFamilia.cep = `${prefixo}-${sufixo}`;
+  }
+
   aoAlterarCidadeFamilia(cidadeId: number | null): void {
     if (cidadeId === null) {
       this.enderecoFamilia.cidadeId = null;


### PR DESCRIPTION
## Resumo
- aplica máscara com hífen ao campo de CEP na tela de nova família
- limita a digitação a oito dígitos e mantém o CEP formatado mesmo quando o usuário insere traços extras

## Testes
- npm test -- --watch=false (frontend)
- npm test (backend-java) *(falha: diretório sem package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e0abdb76788328b03bfe729ac0b504