### PR TITLE
Ajusta placeholder da probabilidade de voto

### DIFF
--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -313,7 +313,7 @@
                 [(ngModel)]="membro.probabilidade"
                 name="probabilidade_{{ i }}"
               >
-                <option value="">Selecione a probabilidade</option>
+                <option value=""></option>
                 <option value="Alta">Alta Probabilidade</option>
                 <option value="Média">Média Probabilidade</option>
                 <option value="Baixa">Baixa Probabilidade</option>


### PR DESCRIPTION
## Resumo
- remove o texto padrão do campo de probabilidade de voto na tela de nova família para deixá-lo vazio

## Testes
- `npm test` (frontend)
- `npm test` (backend-java)

------
https://chatgpt.com/codex/tasks/task_e_68e0ab5e3558832888a1dfb87f6c467f