### PR TITLE
Corrige exibição dos marcadores georreferenciados

### DIFF
--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -9,6 +9,8 @@ interface FamiliaLocalizada {
   enderecoCompleto: string;
   latitude: number;
   longitude: number;
+  latitudeMapa: number;
+  longitudeMapa: number;
   link: string;
 }
 
@@ -27,13 +29,16 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   private assinaturaFamilias: Subscription | null = null;
   private ajusteMapaTimeout: number | null = null;
   private readonly iconeFamilia = L.divIcon({
-
-    html: '<i class="fa-solid fa-house-chimney-window" aria-hidden="true"></i>',
+    html: `
+      <div class="familia-marker__pulse"></div>
+      <div class="familia-marker__icon">
+        <i class="fa-solid fa-house-chimney-window" aria-hidden="true"></i>
+      </div>
+    `,
     className: 'familia-marker',
-    iconSize: [40, 40],
-    iconAnchor: [20, 40],
-    popupAnchor: [0, -32]
-
+    iconSize: [48, 48],
+    iconAnchor: [24, 48],
+    popupAnchor: [0, -42]
   });
 
   constructor(private readonly familiasService: FamiliasService, private readonly router: Router) {}
@@ -73,6 +78,7 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
         this.familiasLocalizadas = familias
           .map(familia => this.converterFamilia(familia))
           .filter((familia): familia is FamiliaLocalizada => familia !== null);
+        this.aplicarDeslocamentoMarcadores();
         this.carregando = false;
         this.atualizarMapa();
       },
@@ -134,7 +140,7 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
     this.familiasLocalizadas.forEach(familia => {
       const marcador = this.criarMarcador(familia);
       marcador.addTo(this.camadaMarcadores as L.LayerGroup);
-      coordenadas.push([familia.latitude, familia.longitude]);
+      coordenadas.push([familia.latitudeMapa, familia.longitudeMapa]);
     });
 
     if (coordenadas.length === 1) {
@@ -185,6 +191,8 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
       enderecoCompleto: this.montarEndereco(enderecoDetalhado),
       latitude,
       longitude,
+      latitudeMapa: latitude,
+      longitudeMapa: longitude,
       link: this.montarLinkFamilia(familia.id)
     };
   }
@@ -226,7 +234,7 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   }
 
   private criarMarcador(familia: FamiliaLocalizada): L.Marker {
-    return L.marker([familia.latitude, familia.longitude], {
+    return L.marker([familia.latitudeMapa, familia.longitudeMapa], {
       icon: this.iconeFamilia
     }).bindPopup(this.criarConteudoPopup(familia));
   }
@@ -270,6 +278,42 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
       return null;
     }
 
-    return maiorGrupo.map(familia => [familia.latitude, familia.longitude] as L.LatLngExpression);
+    return maiorGrupo.map(familia => [familia.latitudeMapa, familia.longitudeMapa] as L.LatLngExpression);
+  }
+
+  private aplicarDeslocamentoMarcadores(): void {
+    if (this.familiasLocalizadas.length === 0) {
+      return;
+    }
+
+    const grupos = new Map<string, FamiliaLocalizada[]>();
+
+    this.familiasLocalizadas.forEach(familia => {
+      familia.latitudeMapa = familia.latitude;
+      familia.longitudeMapa = familia.longitude;
+      const chave = `${familia.latitude.toFixed(6)}-${familia.longitude.toFixed(6)}`;
+      const grupoAtual = grupos.get(chave) ?? [];
+      grupoAtual.push(familia);
+      grupos.set(chave, grupoAtual);
+    });
+
+    grupos.forEach(grupo => {
+      if (grupo.length < 2) {
+        return;
+      }
+
+      const deslocamentoBase = 0.00005;
+      const anguloIncremento = (2 * Math.PI) / grupo.length;
+
+      grupo.forEach((familia, indice) => {
+        const angulo = anguloIncremento * indice;
+        const cosLatitude = Math.cos((familia.latitude * Math.PI) / 180);
+        const ajusteLongitude = Math.abs(cosLatitude) < 1e-6 ? 1 : cosLatitude;
+        const deslocamentoLat = deslocamentoBase * Math.sin(angulo);
+        const deslocamentoLng = (deslocamentoBase * Math.cos(angulo)) / ajusteLongitude;
+        familia.latitudeMapa = familia.latitude + deslocamentoLat;
+        familia.longitudeMapa = familia.longitude + deslocamentoLng;
+      });
+    });
   }
 }


### PR DESCRIPTION
## Resumo
- ajusta o ícone personalizado dos marcadores para manter o alinhamento com o ponto geográfico em todos os níveis de zoom
- aplica pequenos deslocamentos em marcadores com coordenadas idênticas para permitir a visualização de todas as famílias

## Testes
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e0aac4313c8328bf0ffb0cf9232461