### PR TITLE
Ajusta distribuicao das abas no topo

### DIFF
--- a/frontend/src/app/components/top-nav/top-nav.component.html
+++ b/frontend/src/app/components/top-nav/top-nav.component.html
@@ -1,6 +1,6 @@
 <nav class="bg-white/90 backdrop-blur border-b border-gray-200 shadow-sm">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="flex h-16 items-center justify-between">
+  <div class="w-full px-4 sm:px-6 lg:px-8">
+    <div class="flex h-16 items-center justify-between gap-4">
       <div class="flex items-center space-x-3">
         <div class="w-10 h-10 gradient-blue rounded-xl flex items-center justify-center shadow-lg">
           <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -14,24 +14,24 @@
         </div>
       </div>
 
-      <div class="hidden md:flex items-center space-x-1">
+      <div class="hidden md:flex flex-1 items-center gap-2 justify-evenly overflow-x-auto">
         <a
           *ngFor="let item of menuItems"
           [routerLink]="item.route"
           routerLinkActive="active-nav"
           [routerLinkActiveOptions]="{ exact: item.route === '/dashboard' }"
-          class="relative px-4 py-2 rounded-xl text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 transition-colors flex items-center space-x-2"
+          class="group relative flex flex-1 basis-0 min-w-[10rem] items-center gap-2 rounded-xl px-3 py-2 text-xs font-semibold text-gray-600 transition-colors hover:bg-blue-50 hover:text-blue-600"
         >
           <span class="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-50 text-blue-500">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
               <path [attr.d]="item.icon" stroke-linecap="round" stroke-linejoin="round"></path>
             </svg>
           </span>
-          <span>
-            <span class="block">{{ item.label }}</span>
-            <span class="block text-[11px] text-gray-400">{{ item.description }}</span>
+          <span class="min-w-0">
+            <span class="block truncate text-[13px]">{{ item.label }}</span>
+            <span class="block truncate text-[11px] leading-tight text-gray-400">{{ item.description }}</span>
           </span>
-          <span class="absolute inset-x-4 -bottom-1 h-1 rounded-full bg-gradient-to-r from-blue-400 to-blue-600 opacity-0 transition-opacity" aria-hidden="true"></span>
+          <span class="absolute inset-x-4 -bottom-1 h-1 rounded-full bg-gradient-to-r from-blue-400 to-blue-600 opacity-0 transition-opacity group-hover:opacity-100" aria-hidden="true"></span>
         </a>
       </div>
 


### PR DESCRIPTION
## Resumo
- ocupa toda a largura disponível no topo removendo a limitação de largura fixa
- distribui as abas igualmente, reduzindo o tamanho das legendas e evitando sobreposição

## Testes
- npm test (backend-java) *(falhou: package.json ausente)*
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68e0ab0a12108328a3217bf35a3f3386