### PR TITLE
Padroniza notificações de erro no frontend

### DIFF
--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -13,6 +13,7 @@ import {
   Cidade,
   Regiao
 } from '../shared/services/localidades.service';
+import { NotificationService } from '../shared/services/notification.service';
 
 type RegiaoFiltro = Regiao & { cidadeId: number; cidadeNome: string };
 
@@ -52,7 +53,8 @@ export class FamiliasComponent implements OnInit {
     private readonly route: ActivatedRoute,
     private readonly fb: FormBuilder,
     private readonly localidadesService: LocalidadesService,
-    private readonly router: Router
+    private readonly router: Router,
+    private readonly notificationService: NotificationService
   ) {
     this.filtroForm = this.fb.group({
       cidadeId: [null],
@@ -84,8 +86,11 @@ export class FamiliasComponent implements OnInit {
         this.carregarRegioesIniciais(cidades);
         this.buscarFamilias();
       },
-      error: erro => {
-        console.error('Erro ao carregar cidades', erro);
+      error: _erro => {
+        this.notificationService.showError(
+          'Erro ao carregar cidades',
+          'Não foi possível carregar a lista de cidades. Tente novamente mais tarde.'
+        );
         this.buscarFamilias();
       }
     });
@@ -269,8 +274,11 @@ export class FamiliasComponent implements OnInit {
         this.atualizarDestaques();
         this.carregando = false;
       },
-      error: erro => {
-        console.error('Erro ao carregar famílias', erro);
+      error: _erro => {
+        this.notificationService.showError(
+          'Erro ao carregar famílias',
+          'Não foi possível carregar as famílias cadastradas. Tente novamente.'
+        );
         this.erroCarregamento = 'Não foi possível carregar as famílias cadastradas.';
         this.carregando = false;
       }
@@ -287,8 +295,11 @@ export class FamiliasComponent implements OnInit {
 
     const requisicoes = cidades.map(cidade =>
       this.localidadesService.listarRegioes(cidade.id).pipe(
-        catchError(erro => {
-          console.error(`Erro ao carregar regiões da cidade ${cidade.nome}`, erro);
+        catchError(_erro => {
+          this.notificationService.showError(
+            'Erro ao carregar regiões',
+            `Não foi possível carregar as regiões da cidade ${cidade.nome}.`
+          );
           return of<Regiao[]>([]);
         })
       )
@@ -316,8 +327,11 @@ export class FamiliasComponent implements OnInit {
     this.localidadesService
       .listarRegioes(cidadeId)
       .pipe(
-        catchError(erro => {
-          console.error(`Erro ao carregar regiões da cidade ${cidade.nome}`, erro);
+        catchError(_erro => {
+          this.notificationService.showError(
+            'Erro ao carregar regiões',
+            `Não foi possível carregar as regiões da cidade ${cidade.nome}.`
+          );
           return of<Regiao[]>([]);
         })
       )

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -643,8 +643,7 @@ export class NovaFamiliaComponent implements OnInit {
         this.salvandoFamilia = false;
         this.router.navigate(['/familias']);
       },
-      error: erro => {
-        console.error('Erro ao cadastrar família', erro);
+      error: _erro => {
         this.notificationService.showError(
           'Não foi possível cadastrar a família.',
           'Tente novamente.'

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import * as L from 'leaflet';
 import { Subscription } from 'rxjs';
 import { FamiliasService, FamiliaResponse, EnderecoFamiliaResponse } from '../familias/familias.service';
+import { NotificationService } from '../shared/services/notification.service';
 interface FamiliaLocalizada {
   id: number;
   responsavel: string;
@@ -36,7 +37,11 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
 
   });
 
-  constructor(private readonly familiasService: FamiliasService, private readonly router: Router) {}
+  constructor(
+    private readonly familiasService: FamiliasService,
+    private readonly router: Router,
+    private readonly notificationService: NotificationService
+  ) {}
 
   ngOnInit(): void {
     this.carregarFamilias();
@@ -76,8 +81,11 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
         this.carregando = false;
         this.atualizarMapa();
       },
-      error: erro => {
-        console.error('Erro ao carregar famílias para georreferenciamento', erro);
+      error: _erro => {
+        this.notificationService.showError(
+          'Erro ao carregar famílias',
+          'Não foi possível carregar as famílias cadastradas para o mapa.'
+        );
         this.erroCarregamento = 'Não foi possível carregar as famílias cadastradas.';
         this.carregando = false;
       }

--- a/frontend/src/app/modules/shared/services/auth.service.ts
+++ b/frontend/src/app/modules/shared/services/auth.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, tap } from 'rxjs';
 import { buildApiUrl } from '../api-url.util';
+import { NotificationService } from './notification.service';
 
 export type PerfilUsuario = 'ADMINISTRADOR' | 'USUARIO';
 
@@ -18,7 +19,11 @@ export class AuthService {
   private readonly storageKey = 'gestor-politico-auth';
   private readonly usuarioSubject = new BehaviorSubject<UsuarioAutenticado | null>(this.carregarUsuario());
 
-  constructor(private readonly http: HttpClient, private readonly router: Router) {}
+  constructor(
+    private readonly http: HttpClient,
+    private readonly router: Router,
+    private readonly notificationService: NotificationService
+  ) {}
 
   get usuario$(): Observable<UsuarioAutenticado | null> {
     return this.usuarioSubject.asObservable();
@@ -76,7 +81,10 @@ export class AuthService {
         return usuario;
       }
     } catch (erro) {
-      console.error('Erro ao restaurar usuário autenticado', erro);
+      this.notificationService.showError(
+        'Erro ao restaurar sessão',
+        'Não foi possível restaurar as informações do usuário autenticado.'
+      );
     }
     localStorage.removeItem(this.storageKey);
     return null;


### PR DESCRIPTION
## Summary
- substitui logs de erro por notificações amigáveis nas telas de famílias e georreferenciamento
- trata falhas na restauração de sessão exibindo aviso pelo serviço de notificações
- remove avisos de console redundantes no fluxo de cadastro de famílias

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0abaf33988328b1705b1e05d3de99