### PR TITLE
Remover botão de importação de planilha na tela de famílias

### DIFF
--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -11,9 +11,6 @@
         </p>
       </div>
       <div class="flex items-center gap-3">
-        <button class="px-5 py-3 rounded-2xl border border-gray-200 text-gray-600 text-sm font-medium hover:bg-white transition-all">
-          Importar planilha
-        </button>
         <button
           routerLink="/familias/nova"
           class="px-5 py-3 rounded-2xl gradient-blue text-white text-sm font-semibold shadow-lg hover:opacity-90 transition-all"


### PR DESCRIPTION
## Summary
- remover o botão "Importar planilha" da barra de ações na tela de famílias, mantendo apenas o atalho de nova família

## Testing
- npm test -- --watch=false (frontend)
- npm test -- --watch=false (backend-java) *(falhou: npm não encontrou package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ac95fed88328be9f0f27d45914a5