### PR TITLE
feat: criar tela mobile de famílias

### DIFF
--- a/frontend/src/app/modules/familias/familias.module.ts
+++ b/frontend/src/app/modules/familias/familias.module.ts
@@ -4,14 +4,16 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { FamiliasComponent } from './familias.component';
 import { NovaFamiliaComponent } from './nova-familia/nova-familia.component';
+import { FamiliasMobileComponent } from './mobile/familias-mobile.component';
 
 const routes: Routes = [
   { path: '', component: FamiliasComponent },
+  { path: 'mobile', component: FamiliasMobileComponent },
   { path: 'nova', component: NovaFamiliaComponent }
 ];
 
 @NgModule({
-  declarations: [FamiliasComponent, NovaFamiliaComponent],
+  declarations: [FamiliasComponent, NovaFamiliaComponent, FamiliasMobileComponent],
   imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule.forChild(routes)]
 })
 export class FamiliasModule {}

--- a/frontend/src/app/modules/familias/mobile/familias-mobile.component.css
+++ b/frontend/src/app/modules/familias/mobile/familias-mobile.component.css
@@ -1,0 +1,16 @@
+:host {
+  display: block;
+}
+
+.gradient-blue {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+}
+
+button:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+footer select {
+  background-image: none;
+}

--- a/frontend/src/app/modules/familias/mobile/familias-mobile.component.html
+++ b/frontend/src/app/modules/familias/mobile/familias-mobile.component.html
@@ -1,0 +1,319 @@
+<div class="min-h-screen bg-gradient-to-b from-blue-50 via-white to-white pb-24">
+  <div class="max-w-xl mx-auto px-4 pt-8 space-y-6">
+    <header class="space-y-4">
+      <div class="inline-flex items-center px-3 py-1 rounded-full bg-blue-100 text-blue-600 text-xs font-semibold">
+        Gestão de famílias
+      </div>
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Famílias e núcleos sociais</h1>
+        <p class="text-sm text-gray-600">
+          Acompanhe as mesmas informações da visão web em um formato otimizado para navegação mobile.
+        </p>
+      </div>
+      <button
+        routerLink="/familias/nova"
+        class="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-2xl gradient-blue text-white text-sm font-semibold shadow-lg hover:opacity-90 transition"
+        type="button"
+      >
+        <span class="text-lg">+</span>
+        Nova família
+      </button>
+    </header>
+
+    <section *ngIf="destaques.length > 0" class="overflow-x-auto">
+      <div class="flex gap-4 pb-2">
+        <article
+          *ngFor="let destaque of destaques"
+          class="min-w-[200px] bg-white rounded-3xl p-5 shadow-md border border-white/60"
+        >
+          <div class="text-xs font-semibold text-blue-500 mb-2">{{ destaque.variacao }}</div>
+          <div class="text-2xl font-bold text-gray-900">{{ destaque.valor }}</div>
+          <div class="text-sm text-gray-600">{{ destaque.titulo }}</div>
+          <p class="mt-3 text-xs text-gray-400">{{ destaque.descricao }}</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="bg-white rounded-3xl shadow-lg border border-gray-100 overflow-hidden">
+      <div class="p-5 space-y-4">
+        <div class="flex items-center justify-between">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">Rede familiar cadastrada</h2>
+            <p class="text-xs text-gray-500">Filtros e indicadores idênticos à versão desktop.</p>
+          </div>
+          <button
+            type="button"
+            (click)="alternarFiltros()"
+            class="p-2 rounded-full border border-gray-200 text-blue-600 hover:bg-blue-50"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h18M3 12h18M3 20h18" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="grid grid-cols-3 gap-3 text-center">
+          <div class="bg-blue-50 rounded-2xl py-3">
+            <div class="text-xl font-semibold text-blue-600">{{ totalFamilias }}</div>
+            <div class="text-[11px] uppercase tracking-wide text-blue-500">registros</div>
+          </div>
+          <div class="bg-indigo-50 rounded-2xl py-3">
+            <div class="text-xl font-semibold text-indigo-600">{{ responsaveisAtivos }}</div>
+            <div class="text-[11px] uppercase tracking-wide text-indigo-500">responsáveis</div>
+          </div>
+          <div class="bg-cyan-50 rounded-2xl py-3">
+            <div class="text-xl font-semibold text-cyan-600">{{ novosCadastros }}</div>
+            <div class="text-[11px] uppercase tracking-wide text-cyan-500">novos</div>
+          </div>
+        </div>
+      </div>
+
+      <form
+        *ngIf="mostrarFiltros"
+        [formGroup]="filtroForm"
+        (ngSubmit)="aplicarFiltros()"
+        class="border-t border-gray-100 bg-gray-50 p-5 space-y-5"
+        autocomplete="off"
+      >
+        <div class="flex flex-col gap-2">
+          <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Busca livre</label>
+          <input
+            type="text"
+            formControlName="termo"
+            placeholder="Nome, endereço ou palavra-chave"
+            class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <div class="grid grid-cols-1 gap-4">
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Cidade</label>
+            <select
+              formControlName="cidadeId"
+              class="px-4 py-3 rounded-2xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              (change)="onCidadeChange($event.target.value)"
+            >
+              <option [ngValue]="null">Todas as cidades</option>
+              <option *ngFor="let cidade of cidades" [ngValue]="cidade.id">{{ cidade.nome }} / {{ cidade.uf }}</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Região</label>
+            <select
+              formControlName="regiao"
+              class="px-4 py-3 rounded-2xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todas as regiões</option>
+              <option *ngFor="let regiao of regioes" [value]="regiao.nome">
+                {{ regiao.nome }}{{ cidadeSelecionadaId === null && regiao.cidadeNome ? ' • ' + regiao.cidadeNome : '' }}
+              </option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Responsável</label>
+            <input
+              type="text"
+              formControlName="responsavel"
+              placeholder="Nome do responsável"
+              class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Probabilidade de voto</label>
+            <select
+              formControlName="probabilidadeVoto"
+              class="px-4 py-3 rounded-2xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todas</option>
+              <option *ngFor="let probabilidade of probabilidadesVoto" [value]="probabilidade">{{ probabilidade }}</option>
+            </select>
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div class="flex flex-col gap-2">
+              <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Data inicial</label>
+              <input
+                type="date"
+                formControlName="dataInicio"
+                class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div class="flex flex-col gap-2">
+              <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Data final</label>
+              <input
+                type="date"
+                formControlName="dataFim"
+                class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Bairro</label>
+            <input
+              type="text"
+              formControlName="bairro"
+              placeholder="Nome do bairro"
+              class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Rua</label>
+            <input
+              type="text"
+              formControlName="rua"
+              placeholder="Logradouro"
+              class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Número</label>
+            <input
+              type="text"
+              formControlName="numero"
+              placeholder="Número"
+              class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">CEP</label>
+            <input
+              type="text"
+              formControlName="cep"
+              placeholder="00000-000"
+              class="px-4 py-3 rounded-2xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-3 pt-2">
+          <button
+            type="button"
+            class="px-4 py-3 rounded-2xl border border-gray-300 text-sm font-medium text-gray-700 hover:bg-white"
+            (click)="limparFiltros()"
+          >
+            Limpar
+          </button>
+          <button
+            type="submit"
+            class="px-4 py-3 rounded-2xl gradient-blue text-white text-sm font-semibold shadow-md hover:opacity-90"
+          >
+            Aplicar
+          </button>
+        </div>
+      </form>
+    </section>
+
+    <section class="space-y-4">
+      <div *ngIf="carregando" class="bg-white rounded-3xl shadow-md border border-gray-100 p-5 text-center text-sm text-gray-500">
+        Carregando famílias...
+      </div>
+
+      <div *ngIf="!carregando && erroCarregamento" class="bg-red-50 border border-red-200 rounded-2xl p-4 text-sm text-red-600">
+        {{ erroCarregamento }}
+      </div>
+
+      <div *ngIf="!carregando && familias.length === 0 && !erroCarregamento" class="bg-white rounded-3xl shadow-md border border-gray-100 p-5 text-center text-sm text-gray-500">
+        Nenhuma família encontrada com os filtros aplicados.
+      </div>
+
+      <article
+        *ngFor="let familia of familias"
+        class="bg-white rounded-3xl shadow-md border border-gray-100 p-5 space-y-4"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h3 class="text-lg font-semibold text-gray-900">{{ obterResponsavel(familia) }}</h3>
+            <p class="text-xs text-gray-500">Responsável principal</p>
+          </div>
+          <button
+            type="button"
+            (click)="abrirFamilia(familia)"
+            class="px-3 py-1.5 text-xs font-semibold text-blue-600 bg-blue-50 rounded-full"
+          >
+            Detalhes
+          </button>
+        </div>
+
+        <div class="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <span class="block text-xs text-gray-500 uppercase">Telefone</span>
+            <span class="font-medium text-gray-800">{{ obterTelefoneResponsavel(familia) }}</span>
+          </div>
+          <div>
+            <span class="block text-xs text-gray-500 uppercase">Total de membros</span>
+            <span class="font-medium text-gray-800">{{ obterTotalMembros(familia) }}</span>
+          </div>
+          <div>
+            <span class="block text-xs text-gray-500 uppercase">Probabilidade</span>
+            <span class="font-medium text-gray-800">{{ familia.probabilidadeVoto || 'Não informada' }}</span>
+          </div>
+          <div>
+            <span class="block text-xs text-gray-500 uppercase">Cadastro</span>
+            <span class="font-medium text-gray-800">{{ dataCadastro(familia) }}</span>
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <h4 class="text-xs font-semibold text-gray-500 uppercase">Membros secundários</h4>
+          <ng-container *ngIf="membrosSecundarios(familia) as secundarios">
+            <ul class="space-y-2">
+              <li
+                *ngFor="let membro of secundarios; let ultimo = last"
+                class="text-sm text-gray-700 flex items-center justify-between"
+              >
+                <span>{{ membro.nomeCompleto }}</span>
+                <span class="text-xs text-gray-500">{{ membro.relacaoFamiliar || 'Parente' }}</span>
+                <div *ngIf="!ultimo" class="hidden"></div>
+              </li>
+              <li *ngIf="secundarios.length === 0" class="text-sm text-gray-500">
+                Nenhum membro adicional cadastrado.
+              </li>
+            </ul>
+          </ng-container>
+        </div>
+      </article>
+    </section>
+
+    <footer *ngIf="totalFamilias > 0" class="sticky bottom-6 bg-white/90 backdrop-blur-sm rounded-3xl shadow-lg border border-gray-100 p-4 space-y-3">
+      <div class="flex items-center justify-between text-xs text-gray-500">
+        <span>Exibindo {{ inicioIntervalo }}-{{ fimIntervalo }} de {{ totalFamilias }}</span>
+        <label class="flex items-center gap-2">
+          <span>Tamanho</span>
+          <select
+            class="px-3 py-1.5 rounded-xl border border-gray-200 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            [value]="tamanhoPagina"
+            (change)="alterarTamanhoPagina($event)"
+          >
+            <option *ngFor="let tamanho of tamanhosPagina" [value]="tamanho">{{ tamanho }}</option>
+          </select>
+        </label>
+      </div>
+      <div class="flex items-center justify-between">
+        <button
+          type="button"
+          class="px-4 py-2 rounded-2xl border border-gray-200 text-sm font-medium text-gray-600 disabled:opacity-40"
+          (click)="alterarPagina(-1)"
+          [disabled]="paginaAtual === 0"
+        >
+          Anterior
+        </button>
+        <span class="text-sm font-semibold text-gray-700">Página {{ paginaAtual + 1 }} de {{ totalPaginas }}</span>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-2xl border border-gray-200 text-sm font-medium text-gray-600 disabled:opacity-40"
+          (click)="alterarPagina(1)"
+          [disabled]="paginaAtual >= totalPaginas - 1"
+        >
+          Próxima
+        </button>
+      </div>
+    </footer>
+  </div>
+</div>

--- a/frontend/src/app/modules/familias/mobile/familias-mobile.component.ts
+++ b/frontend/src/app/modules/familias/mobile/familias-mobile.component.ts
@@ -1,0 +1,356 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Subscription, forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import {
+  FamiliasService,
+  FamiliaFiltro,
+  FamiliaResponse
+} from '../familias.service';
+import {
+  LocalidadesService,
+  Cidade,
+  Regiao
+} from '../../shared/services/localidades.service';
+
+interface RegiaoFiltro extends Regiao {
+  cidadeId: number;
+  cidadeNome: string;
+}
+
+@Component({
+  standalone: false,
+  selector: 'app-familias-mobile',
+  templateUrl: './familias-mobile.component.html',
+  styleUrls: ['./familias-mobile.component.css']
+})
+export class FamiliasMobileComponent implements OnInit, OnDestroy {
+  filtroForm: FormGroup;
+  familias: FamiliaResponse[] = [];
+  destaques: { titulo: string; valor: string; variacao: string; descricao: string }[] = [];
+  cidades: Cidade[] = [];
+  regioes: RegiaoFiltro[] = [];
+  tamanhosPagina: number[] = [5, 10, 20];
+  probabilidadesVoto: string[] = ['Alta', 'Média', 'Baixa'];
+
+  carregando = false;
+  erroCarregamento = '';
+  mostrarFiltros = false;
+
+  paginaAtual = 0;
+  tamanhoPagina = 10;
+  totalFamilias = 0;
+  responsaveisAtivos = 0;
+  novosCadastros = 0;
+
+  private todasRegioes: RegiaoFiltro[] = [];
+  private readonly regioesPorCidade = new Map<number, RegiaoFiltro[]>();
+  private assinaturaRegioes: Subscription | null = null;
+
+  constructor(
+    private readonly familiasService: FamiliasService,
+    private readonly localidadesService: LocalidadesService,
+    private readonly router: Router,
+    private readonly fb: FormBuilder
+  ) {
+    this.filtroForm = this.fb.group({
+      cidadeId: [null],
+      regiao: [''],
+      termo: [''],
+      responsavel: [''],
+      probabilidadeVoto: [''],
+      dataInicio: [''],
+      dataFim: [''],
+      bairro: [''],
+      rua: [''],
+      numero: [''],
+      cep: ['']
+    });
+  }
+
+  ngOnInit(): void {
+    this.carregando = true;
+    this.localidadesService.listarCidades().subscribe({
+      next: cidades => {
+        this.cidades = cidades;
+        this.carregarRegioesIniciais(cidades);
+        this.buscarFamilias();
+      },
+      error: erro => {
+        console.error('Erro ao carregar cidades', erro);
+        this.buscarFamilias();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.assinaturaRegioes?.unsubscribe();
+  }
+
+  aplicarFiltros(): void {
+    this.paginaAtual = 0;
+    this.buscarFamilias();
+    this.mostrarFiltros = false;
+  }
+
+  limparFiltros(): void {
+    this.filtroForm.reset({
+      cidadeId: null,
+      regiao: '',
+      termo: '',
+      responsavel: '',
+      probabilidadeVoto: '',
+      dataInicio: '',
+      dataFim: '',
+      bairro: '',
+      rua: '',
+      numero: '',
+      cep: ''
+    });
+    this.regioes = this.todasRegioes;
+    this.aplicarFiltros();
+  }
+
+  alternarFiltros(): void {
+    this.mostrarFiltros = !this.mostrarFiltros;
+  }
+
+  onCidadeChange(valor: string | number | null): void {
+    if (valor === null || valor === '') {
+      this.filtroForm.patchValue({ cidadeId: null, regiao: '' }, { emitEvent: false });
+      this.regioes = this.todasRegioes;
+      this.aplicarFiltros();
+      return;
+    }
+
+    const cidadeId = Number(valor);
+    if (Number.isNaN(cidadeId)) {
+      return;
+    }
+
+    this.filtroForm.patchValue({ cidadeId, regiao: '' }, { emitEvent: false });
+    const regioesCidade = this.regioesPorCidade.get(cidadeId);
+    if (regioesCidade) {
+      this.regioes = regioesCidade;
+    } else {
+      this.regioes = [];
+      this.carregarRegioesPorCidade(cidadeId);
+    }
+    this.aplicarFiltros();
+  }
+
+  alterarPagina(delta: number): void {
+    const novaPagina = this.paginaAtual + delta;
+    if (novaPagina < 0 || novaPagina >= this.totalPaginas) {
+      return;
+    }
+    this.paginaAtual = novaPagina;
+    this.buscarFamilias();
+  }
+
+  alterarTamanhoPagina(evento: Event): void {
+    const valor = Number((evento.target as HTMLSelectElement).value);
+    if (Number.isNaN(valor) || valor <= 0) {
+      return;
+    }
+    this.tamanhoPagina = valor;
+    this.paginaAtual = 0;
+    this.buscarFamilias();
+  }
+
+  abrirFamilia(familia: FamiliaResponse): void {
+    this.router.navigate(['/familias/nova'], {
+      queryParams: { familiaId: familia.id }
+    });
+  }
+
+  get cidadeSelecionadaId(): number | null {
+    const valor = this.filtroForm.get('cidadeId')?.value;
+    if (valor === null || valor === '') {
+      return null;
+    }
+    const numero = typeof valor === 'string' ? Number(valor) : valor;
+    return Number.isNaN(numero) ? null : numero;
+  }
+
+  get totalPaginas(): number {
+    if (this.tamanhoPagina <= 0) {
+      return 1;
+    }
+    return Math.max(1, Math.ceil(this.totalFamilias / this.tamanhoPagina));
+  }
+
+  get inicioIntervalo(): number {
+    if (this.totalFamilias === 0) {
+      return 0;
+    }
+    return this.paginaAtual * this.tamanhoPagina + 1;
+  }
+
+  get fimIntervalo(): number {
+    if (this.totalFamilias === 0) {
+      return 0;
+    }
+    return Math.min(this.totalFamilias, this.inicioIntervalo + this.familias.length - 1);
+  }
+
+  obterResponsavel(familia: FamiliaResponse): string {
+    const responsavel = familia.membros.find(membro => membro.responsavelPrincipal);
+    return responsavel?.nomeCompleto || 'Responsável não informado';
+  }
+
+  obterTelefoneResponsavel(familia: FamiliaResponse): string {
+    const responsavel = familia.membros.find(membro => membro.responsavelPrincipal);
+    return responsavel?.telefones?.[0]?.numero || 'Sem telefone';
+  }
+
+  obterTotalMembros(familia: FamiliaResponse): number {
+    return familia.membros.length;
+  }
+
+  membrosSecundarios(familia: FamiliaResponse): FamiliaResponse['membros'] {
+    return familia.membros.filter(membro => !membro.responsavelPrincipal);
+  }
+
+  dataCadastro(familia: FamiliaResponse): string {
+    const data = familia.dataCadastro ? new Date(familia.dataCadastro) : null;
+    return data ? data.toLocaleDateString() : 'Data não informada';
+  }
+
+  private carregarRegioesIniciais(cidades: Cidade[]): void {
+    if (cidades.length === 0) {
+      this.regioes = [];
+      this.todasRegioes = [];
+      return;
+    }
+
+    const requisicoes = cidades.map(cidade =>
+      this.localidadesService.listarRegioes(cidade.id).pipe(
+        catchError(() => of([] as Regiao[]))
+      )
+    );
+
+    this.assinaturaRegioes = forkJoin(requisicoes).subscribe(respostas => {
+      const todas: RegiaoFiltro[] = [];
+      respostas.forEach((regioes, indice) => {
+        const cidade = cidades[indice];
+        regioes.forEach(regiao => {
+          todas.push({
+            ...regiao,
+            cidadeId: cidade.id,
+            cidadeNome: cidade.nome
+          });
+        });
+        this.regioesPorCidade.set(
+          cidade.id,
+          regioes.map(regiao => ({
+            ...regiao,
+            cidadeId: cidade.id,
+            cidadeNome: cidade.nome
+          }))
+        );
+      });
+      this.todasRegioes = todas;
+      this.regioes = todas;
+    });
+  }
+
+  private carregarRegioesPorCidade(cidadeId: number): void {
+    this.localidadesService.listarRegioes(cidadeId).pipe(
+      catchError(() => of([] as Regiao[]))
+    ).subscribe(regioes => {
+      const adaptadas = regioes.map(regiao => ({
+        ...regiao,
+        cidadeId,
+        cidadeNome: this.obterNomeCidade(cidadeId)
+      }));
+      this.regioesPorCidade.set(cidadeId, adaptadas);
+      if (this.cidadeSelecionadaId === cidadeId) {
+        this.regioes = adaptadas;
+      }
+    });
+  }
+
+  private obterNomeCidade(cidadeId: number): string {
+    const cidade = this.cidades.find(item => item.id === cidadeId);
+    return cidade ? cidade.nome : '';
+  }
+
+  private buscarFamilias(): void {
+    const filtros = this.montarFiltros();
+    this.carregando = true;
+    this.erroCarregamento = '';
+
+    this.familiasService.buscarFamilias(filtros, this.paginaAtual, this.tamanhoPagina).subscribe({
+      next: resposta => {
+        this.familias = resposta.itens;
+        this.totalFamilias = resposta.total;
+        this.responsaveisAtivos = resposta.responsaveisAtivos ?? 0;
+        this.novosCadastros = resposta.novosCadastros ?? 0;
+        this.atualizarDestaques();
+        this.carregando = false;
+      },
+      error: () => {
+        this.carregando = false;
+        this.erroCarregamento = 'Não foi possível carregar as famílias.';
+      }
+    });
+  }
+
+  private montarFiltros(): FamiliaFiltro {
+    const filtros: FamiliaFiltro = {};
+
+    const registrar = <K extends keyof FamiliaFiltro>(campo: K, valor: unknown) => {
+      if (valor === null || valor === undefined) {
+        return;
+      }
+      if (typeof valor === 'string' && valor.trim() === '') {
+        return;
+      }
+      filtros[campo] = valor as FamiliaFiltro[K];
+    };
+
+    const valores = this.filtroForm.value;
+    registrar('cidadeId', valores.cidadeId ? Number(valores.cidadeId) : null);
+    registrar('regiao', valores.regiao);
+    registrar('termo', valores.termo);
+    registrar('responsavel', valores.responsavel);
+    registrar('probabilidadeVoto', valores.probabilidadeVoto);
+    registrar('dataInicio', valores.dataInicio);
+    registrar('dataFim', valores.dataFim);
+    registrar('bairro', valores.bairro);
+    registrar('rua', valores.rua);
+    registrar('numero', valores.numero);
+    registrar('cep', valores.cep);
+
+    return filtros;
+  }
+
+  private atualizarDestaques(): void {
+    const totalFamilias = this.totalFamilias;
+    const responsaveis = this.responsaveisAtivos;
+    const novos = this.novosCadastros;
+
+    this.destaques = [
+      {
+        titulo: 'Famílias',
+        valor: totalFamilias.toString(),
+        variacao: totalFamilias > 0 ? `+${totalFamilias}` : '+0',
+        descricao: 'Total de famílias cadastradas'
+      },
+      {
+        titulo: 'Responsáveis ativos',
+        valor: responsaveis.toString(),
+        variacao: responsaveis > 0 ? `+${responsaveis}` : '+0',
+        descricao: 'Responsáveis principais com contato ativo'
+      },
+      {
+        titulo: 'Novos cadastros',
+        valor: novos.toString(),
+        variacao: novos > 0 ? `+${novos}` : '+0',
+        descricao: 'Famílias cadastradas recentemente'
+      }
+    ];
+  }
+}


### PR DESCRIPTION
## Resumo
- adiciona componente dedicado para a experiência mobile de famílias com os mesmos filtros e dados da versão web
- disponibiliza rota /familias/mobile para navegação e reutilização dos serviços existentes
- cria layout otimizado para toques, cards compactos e resumo fixo com paginação adaptada ao mobile

## Testes
- `npm test -- --watch=false` (frontend)
- `npm test -- --watch=false` (backend-java) *(falha: diretório não possui package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e0add5ed488328a6f9856018c81ff8