### PR TITLE
Remover interface de região personalizada nas configurações

### DIFF
--- a/frontend/src/app/modules/configuracoes/configuracoes.component.html
+++ b/frontend/src/app/modules/configuracoes/configuracoes.component.html
@@ -78,7 +78,7 @@
           <select
             multiple
             class="mt-1 w-full h-40 rounded-xl border-gray-200 focus:border-indigo-500 focus:ring-indigo-500"
-            (change)="atualizarSelecaoBairros($event, 'atribuicao')"
+            (change)="atualizarSelecaoBairros($event)"
           >
             <option *ngFor="let bairro of bairros" [value]="bairro.id">
               {{ bairro.nome }} <span *ngIf="bairro.regiao" class="text-gray-400">- {{ bairro.regiao }}</span>
@@ -137,51 +137,6 @@
           class="px-4 py-2 rounded-xl bg-red-600 text-white font-semibold hover:bg-red-700 transition"
         >
           {{ processandoUnificacao ? 'Unificando...' : 'Unificar bairros' }}
-        </button>
-      </div>
-    </form>
-  </div>
-
-  <div class="bg-white rounded-3xl shadow-xl p-8 space-y-6">
-    <h2 class="text-xl font-semibold text-gray-900">Gerenciar regiões manualmente</h2>
-    <form [formGroup]="regiaoLivreForm" class="space-y-4">
-      <div class="grid md:grid-cols-2 gap-6">
-        <div>
-          <label class="block text-sm font-medium text-gray-700">Nome da região *</label>
-          <input
-            type="text"
-            formControlName="nomeRegiaoLivre"
-            class="mt-1 w-full rounded-xl border-gray-200 focus:border-indigo-500 focus:ring-indigo-500"
-            placeholder="Região personalizada"
-          />
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700">Bairros *</label>
-          <select
-            multiple
-            class="mt-1 w-full h-40 rounded-xl border-gray-200 focus:border-indigo-500 focus:ring-indigo-500"
-            (change)="atualizarSelecaoBairros($event, 'livre')"
-          >
-            <option *ngFor="let bairro of bairros" [value]="bairro.id">
-              {{ bairro.nome }} <span *ngIf="bairro.regiao" class="text-gray-400">- {{ bairro.regiao }}</span>
-            </option>
-          </select>
-        </div>
-      </div>
-      <div class="flex flex-wrap gap-4 justify-end">
-        <button
-          type="button"
-          class="px-4 py-2 rounded-xl border border-gray-300 text-gray-600 hover:bg-gray-100"
-          (click)="removerRegiaoDosBairros()"
-        >
-          Remover região
-        </button>
-        <button
-          type="button"
-          class="px-4 py-2 rounded-xl bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition"
-          (click)="atribuirRegiaoLivre()"
-        >
-          Atribuir região personalizada
         </button>
       </div>
     </form>

--- a/frontend/src/app/modules/configuracoes/configuracoes.component.ts
+++ b/frontend/src/app/modules/configuracoes/configuracoes.component.ts
@@ -35,11 +35,6 @@ export class ConfiguracoesComponent implements OnInit {
     bairrosIds: [[] as number[]]
   });
 
-  regiaoLivreForm = this.fb.group({
-    nomeRegiaoLivre: ['', [Validators.required, Validators.minLength(3)]],
-    bairrosIds: [[] as number[]]
-  });
-
   unificacaoForm = this.fb.group({
     bairroPrincipalId: [null as number | null, Validators.required],
     bairrosDuplicadosIds: [[] as number[]]
@@ -64,7 +59,6 @@ export class ConfiguracoesComponent implements OnInit {
     this.mensagemUnificacao = null;
     this.regiaoForm.reset();
     this.atribuicaoForm.reset();
-    this.regiaoLivreForm.reset();
     this.unificacaoForm.reset();
     this.carregarRegioes();
     this.carregarBairros();
@@ -107,14 +101,10 @@ export class ConfiguracoesComponent implements OnInit {
     });
   }
 
-  atualizarSelecaoBairros(event: Event, controle: 'atribuicao' | 'livre'): void {
+  atualizarSelecaoBairros(event: Event): void {
     const options = Array.from((event.target as HTMLSelectElement).selectedOptions);
     const ids = options.map(option => Number(option.value));
-    if (controle === 'atribuicao') {
-      this.atribuicaoForm.patchValue({ bairrosIds: ids });
-    } else {
-      this.regiaoLivreForm.patchValue({ bairrosIds: ids });
-    }
+    this.atribuicaoForm.patchValue({ bairrosIds: ids });
   }
 
   atualizarDuplicados(event: Event): void {
@@ -149,46 +139,6 @@ export class ConfiguracoesComponent implements OnInit {
       this.carregarBairros();
       this.carregarRegioes();
     });
-  }
-
-  atribuirRegiaoLivre(): void {
-    if (this.regiaoLivreForm.invalid || !this.cidadeSelecionadaId) {
-      this.regiaoLivreForm.markAllAsTouched();
-      return;
-    }
-    const nomeRegiao = this.regiaoLivreForm.value.nomeRegiaoLivre?.trim();
-    const bairrosIds = this.regiaoLivreForm.value.bairrosIds ?? [];
-    if (!nomeRegiao || bairrosIds.length === 0) {
-      window.alert('Informe um nome de região e selecione ao menos um bairro.');
-      return;
-    }
-
-    this.localidadesService
-      .atualizarRegiaoBairros({ bairrosIds, nomeRegiaoLivre: nomeRegiao })
-      .subscribe(() => {
-        this.regiaoLivreForm.reset();
-        this.carregarBairros();
-        this.carregarRegioes();
-      });
-  }
-
-  removerRegiaoDosBairros(): void {
-    if (!this.cidadeSelecionadaId) {
-      return;
-    }
-    const bairrosIds = this.regiaoLivreForm.value.bairrosIds ?? [];
-    if (bairrosIds.length === 0) {
-      window.alert('Selecione os bairros que terão a região removida.');
-      return;
-    }
-
-    this.localidadesService
-      .atualizarRegiaoBairros({ bairrosIds, regiaoId: null })
-      .subscribe(() => {
-        this.regiaoLivreForm.reset();
-        this.carregarBairros();
-        this.carregarRegioes();
-      });
   }
 
   unificarBairros(): void {


### PR DESCRIPTION
## Summary
- remove a seção de gerenciamento de regiões personalizadas na tela de configurações
- simplifica o formulário de vinculação de bairros para lidar apenas com regiões existentes

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e0ad4382408328809989ca9fb29423