### PR TITLE
Remover ícone residual da barra superior

### DIFF
--- a/frontend/src/app/components/top-nav/top-nav.component.html
+++ b/frontend/src/app/components/top-nav/top-nav.component.html
@@ -35,13 +35,7 @@
         </a>
       </div>
 
-      <div class="flex items-center space-x-4" *ngIf="usuarioLogado as usuario">
-        <button class="relative p-2 text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded-xl transition-colors">
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-5 5v-5zM9 17H4l5 5v-5z" />
-          </svg>
-          <span class="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full"></span>
-        </button>
+      <div class="flex items-center" *ngIf="usuarioLogado as usuario">
         <div class="relative">
           <button
             class="flex items-center space-x-3 px-3 py-2 rounded-2xl hover:bg-blue-50 transition-colors"


### PR DESCRIPTION
## Resumo
- remover o botão de ícone intermediário na barra superior para eliminar o avatar residual exibido entre o menu e o perfil
- ajustar o contêiner da área do usuário para manter o alinhamento após a remoção do botão

## Testes
- npm test -- --watch=false (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e0ad14805c83288fc670c06acc00d8