### PR TITLE
Adiciona máscara e contato WhatsApp no mapa de famílias

### DIFF
--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
@@ -26,6 +26,31 @@
   margin-bottom: 0.5rem;
 }
 
+.popup-telefone {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.popup-telefone__label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.popup-telefone__numero {
+  font-weight: 600;
+  color: #111827;
+}
+
+.popup-telefone--ausente .popup-telefone__numero {
+  font-weight: 500;
+  color: #9ca3af;
+}
+
 .popup-link {
   display: inline-flex;
   align-items: center;
@@ -41,6 +66,47 @@
 
 .popup-link .fa-solid {
   font-size: 0.75rem;
+}
+
+.popup-whatsapp {
+  margin-top: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.875rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  box-shadow: 0 10px 20px -10px rgba(34, 197, 94, 0.8);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.popup-whatsapp .fa-brands {
+  font-size: 1rem;
+}
+
+.popup-whatsapp:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px -12px rgba(22, 163, 74, 0.9);
+}
+
+.popup-whatsapp:disabled {
+  opacity: 0.8;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.popup-whatsapp__loading {
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.is-hidden {
+  display: none !important;
 }
 
 .familia-marker {


### PR DESCRIPTION
## Resumo
- exibe o telefone do responsável com máscara no popup do georreferenciamento
- adiciona botão de WhatsApp que gera o link somente ao clicar, abre em nova aba e indica carregamento
- ajusta os estilos do popup para comportar telefone e ação de contato

## Testes
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e0ac80df5c8328a942949a99ab4ec9