### PR TITLE
Adiciona opção de mapa de calor no georreferenciamento

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@types/leaflet": "^1.9.20",
         "chart.js": "^4.4.7",
         "leaflet": "^1.9.4",
+        "leaflet.heat": "^0.2.0",
         "rxjs": "^7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -8704,6 +8705,11 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.heat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet.heat/-/leaflet.heat-0.2.0.tgz",
+      "integrity": "sha512-Cd5PbAA/rX3X3XKxfDoUGi9qp78FyhWYurFg3nsfhntcM/MCNK08pRkf4iEenO1KNqwVPKCmkyktjW3UD+h9bQ=="
     },
     "node_modules/less": {
       "version": "4.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@types/leaflet": "^1.9.20",
     "chart.js": "^4.4.7",
     "leaflet": "^1.9.4",
+    "leaflet.heat": "^0.2.0",
     "rxjs": "^7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
@@ -9,6 +9,83 @@
   box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.08);
 }
 
+.mapa-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(16, 185, 129, 0.12));
+  border: 1px solid rgba(59, 130, 246, 0.16);
+}
+
+@media (min-width: 768px) {
+  .mapa-toolbar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.mapa-toolbar__descricao {
+  max-width: 32rem;
+}
+
+.mapa-toolbar__titulo {
+  margin: 0 0 0.25rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.mapa-toolbar__texto {
+  margin: 0;
+  color: #1f2937;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.mapa-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 9999px;
+  padding: 0.5rem 0.75rem;
+  box-shadow: 0 10px 25px -12px rgba(15, 23, 42, 0.4);
+}
+
+.mapa-view-toggle__botao {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  border-radius: 9999px;
+  border: none;
+  background: transparent;
+  color: #1f2937;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.mapa-view-toggle__botao:hover {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.mapa-view-toggle__botao--ativo {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  box-shadow: 0 12px 20px -10px rgba(37, 99, 235, 0.55);
+}
+
+.mapa-view-toggle__botao--ativo:hover {
+  color: #fff;
+  transform: translateY(-1px);
+}
+
 .popup-conteudo {
   max-width: 220px;
   font-size: 0.875rem;

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.html
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.html
@@ -18,6 +18,37 @@
         </div>
       </div>
 
+      <div class="mapa-toolbar">
+        <div class="mapa-toolbar__descricao">
+          <h2 class="mapa-toolbar__titulo">Visualização do território</h2>
+          <p class="mapa-toolbar__texto">
+            Explore os pontos individuais ou destaque automaticamente as áreas com maior concentração de famílias.
+          </p>
+        </div>
+        <div class="mapa-view-toggle" role="group" aria-label="Alternar visualização do mapa">
+          <button
+            type="button"
+            class="mapa-view-toggle__botao"
+            [class.mapa-view-toggle__botao--ativo]="!exibirMapaDeCalor"
+            (click)="mostrarMarcadores()"
+            [attr.aria-pressed]="!exibirMapaDeCalor"
+          >
+            <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
+            <span>Marcadores</span>
+          </button>
+          <button
+            type="button"
+            class="mapa-view-toggle__botao"
+            [class.mapa-view-toggle__botao--ativo]="exibirMapaDeCalor"
+            (click)="mostrarMapaDeCalor()"
+            [attr.aria-pressed]="exibirMapaDeCalor"
+          >
+            <i class="fa-solid fa-fire" aria-hidden="true"></i>
+            <span>Mapa de calor</span>
+          </button>
+        </div>
+      </div>
+
       <div class="relative">
         <div
           *ngIf="carregando"

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import * as L from 'leaflet';
+import 'leaflet.heat';
 import { Subscription } from 'rxjs';
 import { FamiliasService, FamiliaResponse, EnderecoFamiliaResponse } from '../familias/familias.service';
 interface FamiliaLocalizada {
@@ -22,8 +23,10 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   carregando = false;
   erroCarregamento = '';
   familiasLocalizadas: FamiliaLocalizada[] = [];
+  exibirMapaDeCalor = false;
   private mapa: L.Map | null = null;
   private camadaMarcadores: L.LayerGroup | null = null;
+  private camadaCalor: L.HeatLayer | null = null;
   private assinaturaFamilias: Subscription | null = null;
   private ajusteMapaTimeout: number | null = null;
   private readonly iconeFamilia = L.divIcon({
@@ -54,6 +57,8 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
       this.ajusteMapaTimeout = null;
     }
     this.assinaturaFamilias?.unsubscribe();
+    this.removerCamadaCalor();
+    this.removerCamadaMarcadores();
     if (this.mapa) {
       this.mapa.remove();
       this.mapa = null;
@@ -120,37 +125,23 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
     }
 
     this.agendarAjusteMapa();
-
-    if (!this.camadaMarcadores) {
-      this.camadaMarcadores = L.layerGroup().addTo(this.mapa);
-    }
-    this.camadaMarcadores.clearLayers();
-
     if (this.familiasLocalizadas.length === 0) {
+      this.removerCamadaCalor();
+      this.removerCamadaMarcadores();
       return;
     }
 
-    const coordenadas: L.LatLngExpression[] = [];
-    this.familiasLocalizadas.forEach(familia => {
-      const marcador = this.criarMarcador(familia);
-      marcador.addTo(this.camadaMarcadores as L.LayerGroup);
-      coordenadas.push([familia.latitude, familia.longitude]);
-    });
+    const coordenadas = this.familiasLocalizadas.map(familia => [familia.latitude, familia.longitude] as L.LatLngExpression);
 
-    if (coordenadas.length === 1) {
-      this.mapa.setView(coordenadas[0], 15);
-      return;
+    if (this.exibirMapaDeCalor) {
+      this.removerCamadaMarcadores();
+      this.atualizarMapaDeCalor();
+    } else {
+      this.removerCamadaCalor();
+      this.atualizarMarcadores();
     }
 
-    const grupoMaisDenso = this.obterGrupoMaisDenso();
-    if (grupoMaisDenso) {
-      const limitesGrupo = L.latLngBounds(grupoMaisDenso);
-      this.mapa.fitBounds(limitesGrupo, { padding: [40, 40], maxZoom: 16 });
-      return;
-    }
-
-    const limites = L.latLngBounds(coordenadas);
-    this.mapa.fitBounds(limites, { padding: [40, 40] });
+    this.ajustarVisaoMapa(coordenadas);
   }
 
   private agendarAjusteMapa(): void {
@@ -229,6 +220,101 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
     return L.marker([familia.latitude, familia.longitude], {
       icon: this.iconeFamilia
     }).bindPopup(this.criarConteudoPopup(familia));
+  }
+
+  private atualizarMarcadores(): void {
+    if (!this.mapa) {
+      return;
+    }
+
+    if (!this.camadaMarcadores) {
+      this.camadaMarcadores = L.layerGroup().addTo(this.mapa);
+    }
+
+    this.camadaMarcadores.clearLayers();
+
+    this.familiasLocalizadas.forEach(familia => {
+      const marcador = this.criarMarcador(familia);
+      marcador.addTo(this.camadaMarcadores as L.LayerGroup);
+    });
+  }
+
+  private atualizarMapaDeCalor(): void {
+    if (!this.mapa) {
+      return;
+    }
+
+    const pontosCalor: L.HeatLatLngTuple[] = this.familiasLocalizadas.map(familia => [familia.latitude, familia.longitude, 0.6]);
+
+    if (!this.camadaCalor) {
+      this.camadaCalor = L.heatLayer(pontosCalor, {
+        radius: 28,
+        blur: 18,
+        maxZoom: 17,
+        minOpacity: 0.35
+      }).addTo(this.mapa);
+      return;
+    }
+
+    this.camadaCalor.setLatLngs(pontosCalor);
+  }
+
+  private removerCamadaMarcadores(): void {
+    if (!this.camadaMarcadores) {
+      return;
+    }
+
+    this.camadaMarcadores.clearLayers();
+    if (this.mapa) {
+      this.mapa.removeLayer(this.camadaMarcadores);
+    }
+    this.camadaMarcadores = null;
+  }
+
+  private removerCamadaCalor(): void {
+    if (!this.camadaCalor) {
+      return;
+    }
+
+    if (this.mapa) {
+      this.mapa.removeLayer(this.camadaCalor);
+    }
+    this.camadaCalor = null;
+  }
+
+  private ajustarVisaoMapa(coordenadas: L.LatLngExpression[]): void {
+    if (!this.mapa || coordenadas.length === 0) {
+      return;
+    }
+
+    if (coordenadas.length === 1) {
+      this.mapa.setView(coordenadas[0], 15);
+      return;
+    }
+
+    const grupoMaisDenso = this.obterGrupoMaisDenso();
+    if (grupoMaisDenso) {
+      const limitesGrupo = L.latLngBounds(grupoMaisDenso);
+      this.mapa.fitBounds(limitesGrupo, { padding: [40, 40], maxZoom: 16 });
+      return;
+    }
+
+    const limites = L.latLngBounds(coordenadas);
+    this.mapa.fitBounds(limites, { padding: [40, 40] });
+  }
+
+  mostrarMarcadores(): void {
+    if (this.exibirMapaDeCalor) {
+      this.exibirMapaDeCalor = false;
+      this.atualizarMapa();
+    }
+  }
+
+  mostrarMapaDeCalor(): void {
+    if (!this.exibirMapaDeCalor) {
+      this.exibirMapaDeCalor = true;
+      this.atualizarMapa();
+    }
   }
 
   private escapeHtml(valor: string): string {

--- a/frontend/src/types/leaflet-heat.d.ts
+++ b/frontend/src/types/leaflet-heat.d.ts
@@ -1,0 +1,20 @@
+import * as L from 'leaflet';
+
+declare module 'leaflet' {
+  type HeatLatLngTuple = [number, number, number?];
+
+  interface HeatLayerOptions {
+    minOpacity?: number;
+    maxZoom?: number;
+    radius?: number;
+    blur?: number;
+    gradient?: Record<number, string>;
+  }
+
+  interface HeatLayer extends L.Layer {
+    setLatLngs(latlngs: HeatLatLngTuple[]): this;
+    addLatLng(latlng: HeatLatLngTuple): this;
+  }
+
+  function heatLayer(latlngs: HeatLatLngTuple[], options?: HeatLayerOptions): HeatLayer;
+}


### PR DESCRIPTION
## Resumo
- adiciona a dependência leaflet.heat e declarações de tipos para suportar o plugin no projeto Angular
- cria controles para alternar entre marcadores e mapa de calor no módulo de georreferenciamento e ajusta a lógica de renderização
- atualiza o layout da página com toolbar descritiva e estilos para o seletor de visualização do mapa

## Testes
- npm test (frontend)
- npm test (backend-java) *(falha: diretório não contém package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e0aadc36f88328ba4bc928f0d09ea8