### PR TITLE
Adiciona métricas de pessoas na tela de famílias

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaListaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaListaResponseDTO.java
@@ -10,6 +10,8 @@ public class FamiliaListaResponseDTO {
   private int tamanho;
   private long responsaveisAtivos;
   private long novosCadastros;
+  private long totalPessoas;
+  private long novasPessoasSemana;
 
   public FamiliaListaResponseDTO() {}
 
@@ -19,7 +21,9 @@ public class FamiliaListaResponseDTO {
     int pagina,
     int tamanho,
     long responsaveisAtivos,
-    long novosCadastros
+    long novosCadastros,
+    long totalPessoas,
+    long novasPessoasSemana
   ) {
     if (familias != null) {
       this.familias = familias;
@@ -29,6 +33,8 @@ public class FamiliaListaResponseDTO {
     this.tamanho = tamanho;
     this.responsaveisAtivos = responsaveisAtivos;
     this.novosCadastros = novosCadastros;
+    this.totalPessoas = totalPessoas;
+    this.novasPessoasSemana = novasPessoasSemana;
   }
 
   public List<FamiliaResponseDTO> getFamilias() {
@@ -77,5 +83,21 @@ public class FamiliaListaResponseDTO {
 
   public void setNovosCadastros(long novosCadastros) {
     this.novosCadastros = novosCadastros;
+  }
+
+  public long getTotalPessoas() {
+    return totalPessoas;
+  }
+
+  public void setTotalPessoas(long totalPessoas) {
+    this.totalPessoas = totalPessoas;
+  }
+
+  public long getNovasPessoasSemana() {
+    return novasPessoasSemana;
+  }
+
+  public void setNovasPessoasSemana(long novasPessoasSemana) {
+    this.novasPessoasSemana = novasPessoasSemana;
   }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/service/FamiliaService.java
+++ b/backend-java/src/main/java/com/gestorpolitico/service/FamiliaService.java
@@ -142,13 +142,26 @@ public class FamiliaService {
       .filter(familia -> familia.getCriadoEm() != null && familia.getCriadoEm().isAfter(seteDiasAtras))
       .count();
 
+    long totalPessoas = familiasFiltradas
+      .stream()
+      .mapToLong(familia -> familia.getMembros().size())
+      .sum();
+
+    long novasPessoasSemana = familiasFiltradas
+      .stream()
+      .flatMap(familia -> familia.getMembros().stream())
+      .filter(membro -> membro.getCriadoEm() != null && membro.getCriadoEm().isAfter(seteDiasAtras))
+      .count();
+
     return new FamiliaListaResponseDTO(
       familias,
       pagina.getTotalElements(),
       pagina.getNumber(),
       pagina.getSize(),
       responsaveisAtivos,
-      novosCadastros
+      novosCadastros,
+      totalPessoas,
+      novasPessoasSemana
     );
   }
 

--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -24,7 +24,7 @@
       </div>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10" *ngIf="destaques.length > 0">
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mb-10" *ngIf="destaques.length > 0">
       <div
         *ngFor="let destaque of destaques"
         class="bg-white rounded-3xl p-6 shadow-lg border border-gray-100 hover:shadow-xl transition-all duration-300"
@@ -49,18 +49,22 @@
             <div class="text-sm text-gray-500">Listagem com filtros inteligentes</div>
           </div>
         </div>
-        <div class="flex items-center gap-6 text-sm text-gray-600">
+        <div class="flex flex-wrap items-center gap-6 text-sm text-gray-600">
           <div>
             <div class="text-lg font-semibold text-gray-900">{{ totalFamilias }}</div>
-            <div class="text-xs text-gray-500 uppercase tracking-wide">registros encontrados</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wide">famílias cadastradas</div>
           </div>
           <div>
-            <div class="text-lg font-semibold text-gray-900">{{ responsaveisAtivos }}</div>
-            <div class="text-xs text-gray-500 uppercase tracking-wide">responsáveis ativos</div>
+            <div class="text-lg font-semibold text-gray-900">{{ totalPessoas }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wide">pessoas vinculadas</div>
           </div>
           <div>
             <div class="text-lg font-semibold text-gray-900">{{ novosCadastros }}</div>
-            <div class="text-xs text-gray-500 uppercase tracking-wide">novos na semana</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wide">novas famílias na semana</div>
+          </div>
+          <div>
+            <div class="text-lg font-semibold text-gray-900">{{ novasPessoasSemana }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wide">novas pessoas na semana</div>
           </div>
         </div>
       </div>

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -41,6 +41,8 @@ export class FamiliasComponent implements OnInit {
   totalFamilias = 0;
   responsaveisAtivos = 0;
   novosCadastros = 0;
+  totalPessoas = 0;
+  novasPessoasSemana = 0;
 
   familiaSelecionadaId: number | null = null;
   mostrarFiltrosAvancados = false;
@@ -258,6 +260,8 @@ export class FamiliasComponent implements OnInit {
         this.totalFamilias = resposta.total;
         this.responsaveisAtivos = resposta.responsaveisAtivos;
         this.novosCadastros = resposta.novosCadastros;
+        this.totalPessoas = resposta.totalPessoas;
+        this.novasPessoasSemana = resposta.novasPessoasSemana;
 
         const ultimaPagina = Math.max(this.totalPaginas - 1, 0);
         if (this.familias.length === 0 && this.totalFamilias > 0 && this.paginaAtual > ultimaPagina) {
@@ -404,8 +408,9 @@ export class FamiliasComponent implements OnInit {
 
   private atualizarDestaques(): void {
     const totalFamilias = this.totalFamilias;
-    const responsaveisAtivos = this.responsaveisAtivos;
+    const totalPessoas = this.totalPessoas;
     const novosCadastros = this.novosCadastros;
+    const novasPessoasSemana = this.novasPessoasSemana;
 
     this.destaques = [
       {
@@ -415,16 +420,22 @@ export class FamiliasComponent implements OnInit {
         descricao: 'total registrado na base'
       },
       {
-        titulo: 'Responsáveis ativos',
-        valor: responsaveisAtivos.toString(),
-        variacao: responsaveisAtivos > 0 ? `+${responsaveisAtivos}` : '+0',
-        descricao: 'famílias com responsável definido'
+        titulo: 'Pessoas cadastradas',
+        valor: totalPessoas.toString(),
+        variacao: totalPessoas > 0 ? `+${totalPessoas}` : '+0',
+        descricao: 'membros distribuídos nas famílias'
       },
       {
-        titulo: 'Novos cadastros',
+        titulo: 'Novas famílias na semana',
         valor: novosCadastros.toString(),
         variacao: `+${novosCadastros} nesta semana`,
-        descricao: 'entradas nos últimos 7 dias'
+        descricao: 'entradas de núcleos familiares'
+      },
+      {
+        titulo: 'Novas pessoas na semana',
+        valor: novasPessoasSemana.toString(),
+        variacao: `+${novasPessoasSemana} nesta semana`,
+        descricao: 'membros adicionados nos últimos 7 dias'
       }
     ];
   }

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -78,6 +78,8 @@ export interface FamiliaListaResponse {
   tamanho: number;
   responsaveisAtivos: number;
   novosCadastros: number;
+  totalPessoas: number;
+  novasPessoasSemana: number;
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Resumo
- calcula no backend o total de pessoas e o número de novos membros na semana
- expõe os novos campos no serviço Angular e atualiza os destaques da tela de famílias
- ajusta o layout dos contadores para exibir totais e entradas semanais de famílias e pessoas

## Testes
- npm test (frontend)
- npm test (backend-java) *(falhou: package.json ausente)*
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e0aa07a3b88328a298524ea0887bd3