### PR TITLE
Adiciona suporte à edição de famílias

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/controller/FamiliaController.java
+++ b/backend-java/src/main/java/com/gestorpolitico/controller/FamiliaController.java
@@ -9,7 +9,9 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +35,12 @@ public class FamiliaController {
     return ResponseEntity.status(HttpStatus.CREATED).body(familia);
   }
 
+  @GetMapping("/{id}")
+  public ResponseEntity<FamiliaResponseDTO> buscarFamilia(@PathVariable Long id) {
+    FamiliaResponseDTO familia = familiaService.buscarFamilia(id);
+    return ResponseEntity.ok(familia);
+  }
+
   @GetMapping
   public ResponseEntity<FamiliaListaResponseDTO> listarFamilias(
     FamiliaFiltroRequestDTO filtro,
@@ -44,5 +52,14 @@ public class FamiliaController {
     Pageable pageable = PageRequest.of(paginaAjustada, tamanhoAjustado, Sort.by(Sort.Direction.DESC, "criadoEm"));
     FamiliaListaResponseDTO familias = familiaService.buscarFamilias(filtro, pageable);
     return ResponseEntity.ok(familias);
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<FamiliaResponseDTO> atualizarFamilia(
+    @PathVariable Long id,
+    @Valid @RequestBody FamiliaRequestDTO request
+  ) {
+    FamiliaResponseDTO familia = familiaService.atualizarFamilia(id, request);
+    return ResponseEntity.ok(familia);
   }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/service/FamiliaService.java
+++ b/backend-java/src/main/java/com/gestorpolitico/service/FamiliaService.java
@@ -70,48 +70,32 @@ public class FamiliaService {
 
   @Transactional
   public FamiliaResponseDTO salvarFamilia(FamiliaRequestDTO dto) {
-    if (dto.getMembros() == null || dto.getMembros().isEmpty()) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe ao menos um membro da família.");
-    }
-
-    boolean possuiResponsavel = dto.getMembros().stream()
-      .map(MembroFamiliaRequestDTO::getResponsavelPrincipal)
-      .anyMatch(Boolean.TRUE::equals);
-
-    if (!possuiResponsavel) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Defina um responsável principal para a família.");
-    }
-
-    Cidade cidade = cidadeRepository
-      .findById(dto.getCidadeId())
-      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Cidade não encontrada"));
-
-    String cepSanitizado = sanitizarCep(dto.getCep());
-    if (cepSanitizado.length() != 8) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe um CEP válido com 8 dígitos.");
-    }
-
-    CepResultado cepResultado = cepService
-      .consultarCep(cepSanitizado)
-      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CEP não encontrado"));
-
-    validarCidadeComCep(cidade, cepResultado);
-
-    Bairro bairro = resolverBairroFamilia(dto, cidade, cepResultado);
-    Endereco endereco = construirEnderecoFamilia(dto, cidade, bairro, cepResultado, cepSanitizado);
-
+    DadosFamilia dados = prepararDadosFamilia(dto);
     Familia familia = new Familia();
-    familia.setEndereco(montarEnderecoResumo(dto));
-    familia.setBairro(bairro.getNome());
-    familia.setEnderecoDetalhado(endereco);
-
-    List<MembroFamilia> membros = dto.getMembros().stream()
-      .map(this::converterMembro)
-      .collect(Collectors.toList());
-    membros.forEach(familia::adicionarMembro);
-
+    aplicarDadosFamilia(familia, dados);
     Familia salvo = familiaRepository.save(familia);
     return converterFamilia(salvo);
+  }
+
+  @Transactional(readOnly = true)
+  public FamiliaResponseDTO buscarFamilia(Long id) {
+    Familia familia = familiaRepository
+      .findById(id)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Família não encontrada"));
+    return converterFamilia(familia);
+  }
+
+  @Transactional
+  public FamiliaResponseDTO atualizarFamilia(Long id, FamiliaRequestDTO dto) {
+    Familia familia = familiaRepository
+      .findById(id)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Família não encontrada"));
+
+    DadosFamilia dados = prepararDadosFamilia(dto);
+    familia.getMembros().clear();
+    aplicarDadosFamilia(familia, dados);
+    Familia atualizado = familiaRepository.save(familia);
+    return converterFamilia(atualizado);
   }
 
   @Transactional(readOnly = true)
@@ -150,6 +134,55 @@ public class FamiliaService {
       responsaveisAtivos,
       novosCadastros
     );
+  }
+
+  private DadosFamilia prepararDadosFamilia(FamiliaRequestDTO dto) {
+    validarMembros(dto);
+
+    Cidade cidade = cidadeRepository
+      .findById(dto.getCidadeId())
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Cidade não encontrada"));
+
+    String cepSanitizado = sanitizarCep(dto.getCep());
+    if (cepSanitizado.length() != 8) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe um CEP válido com 8 dígitos.");
+    }
+
+    CepResultado cepResultado = cepService
+      .consultarCep(cepSanitizado)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CEP não encontrado"));
+
+    validarCidadeComCep(cidade, cepResultado);
+
+    Bairro bairro = resolverBairroFamilia(dto, cidade, cepResultado);
+    Endereco endereco = construirEnderecoFamilia(dto, cidade, bairro, cepResultado, cepSanitizado);
+
+    List<MembroFamilia> membros = dto.getMembros().stream()
+      .map(this::converterMembro)
+      .collect(Collectors.toList());
+
+    return new DadosFamilia(montarEnderecoResumo(dto), bairro, endereco, membros);
+  }
+
+  private void aplicarDadosFamilia(Familia familia, DadosFamilia dados) {
+    familia.setEndereco(dados.enderecoResumo());
+    familia.setBairro(dados.bairro().getNome());
+    familia.setEnderecoDetalhado(dados.endereco());
+    dados.membros().forEach(familia::adicionarMembro);
+  }
+
+  private void validarMembros(FamiliaRequestDTO dto) {
+    if (dto.getMembros() == null || dto.getMembros().isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe ao menos um membro da família.");
+    }
+
+    boolean possuiResponsavel = dto.getMembros().stream()
+      .map(MembroFamiliaRequestDTO::getResponsavelPrincipal)
+      .anyMatch(Boolean.TRUE::equals);
+
+    if (!possuiResponsavel) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Defina um responsável principal para a família.");
+    }
   }
 
   private MembroFamilia converterMembro(MembroFamiliaRequestDTO dto) {
@@ -576,4 +609,11 @@ public class FamiliaService {
       .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
     return semAcento.toUpperCase(Locale.ROOT).replaceAll("\\s+", " ").trim();
   }
+
+  private record DadosFamilia(
+    String enderecoResumo,
+    Bairro bairro,
+    Endereco endereco,
+    List<MembroFamilia> membros
+  ) {}
 }

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -154,9 +154,7 @@ export class FamiliasComponent implements OnInit {
 
   abrirFamilia(familia: FamiliaResponse): void {
     this.familiaSelecionadaId = familia.id;
-    this.router.navigate(['/familias/nova'], {
-      queryParams: { familiaId: familia.id }
-    });
+    this.router.navigate(['/familias', 'editar', familia.id]);
   }
 
   alterarTamanhoPagina(evento: Event): void {

--- a/frontend/src/app/modules/familias/familias.module.ts
+++ b/frontend/src/app/modules/familias/familias.module.ts
@@ -7,7 +7,8 @@ import { NovaFamiliaComponent } from './nova-familia/nova-familia.component';
 
 const routes: Routes = [
   { path: '', component: FamiliasComponent },
-  { path: 'nova', component: NovaFamiliaComponent }
+  { path: 'nova', component: NovaFamiliaComponent },
+  { path: 'editar/:id', component: NovaFamiliaComponent }
 ];
 
 @NgModule({

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -113,7 +113,15 @@ export class FamiliasService {
     return this.buscarFamilias(filtros, 0, 1000).pipe(map(resposta => resposta.familias));
   }
 
+  obterFamilia(id: number): Observable<FamiliaResponse> {
+    return this.http.get<FamiliaResponse>(`${this.apiUrl}/${id}`);
+  }
+
   criarFamilia(payload: FamiliaPayload): Observable<FamiliaResponse> {
     return this.http.post<FamiliaResponse>(this.apiUrl, payload);
+  }
+
+  atualizarFamilia(id: number, payload: FamiliaPayload): Observable<FamiliaResponse> {
+    return this.http.put<FamiliaResponse>(`${this.apiUrl}/${id}`, payload);
   }
 }

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -12,13 +12,20 @@
           </svg>
         </button>
         <div class="w-10 h-10 gradient-blue rounded-xl flex items-center justify-center">
-          <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
-          </svg>
+          <ng-container *ngIf="!modoEdicao; else editarIcone">
+            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+            </svg>
+          </ng-container>
+          <ng-template #editarIcone>
+            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5h2m-1 12v2m-7.657-7.657l1.414 1.414M18.364 7.05l1.414-1.414M5 13H3m18 0h-2m-2.05-5.95l-9.9 9.9a1.5 1.5 0 01-2.122-2.121l9.9-9.9A3 3 0 1119.95 7.05z"></path>
+            </svg>
+          </ng-template>
         </div>
         <div>
-          <h1 class="text-2xl font-bold text-gray-900">Nova Família</h1>
-          <p class="text-sm text-gray-600">Cadastro de família e membros</p>
+          <h1 class="text-2xl font-bold text-gray-900">{{ tituloPagina }}</h1>
+          <p class="text-sm text-gray-600">{{ descricaoPagina }}</p>
         </div>
       </div>
       <div class="flex items-center">
@@ -359,19 +366,42 @@
       <button
         type="button"
         (click)="visualizarPrevia()"
-        class="px-8 py-3 bg-gray-100 text-gray-700 rounded-xl font-semibold hover:bg-gray-200 transition-all duration-200"
+        [disabled]="carregandoFamilia"
+        class="px-8 py-3 bg-gray-100 text-gray-700 rounded-xl font-semibold hover:bg-gray-200 transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
       >
         Visualizar Prévia
       </button>
       <button
         type="button"
         (click)="cadastrarFamilia()"
-        [disabled]="salvandoFamilia"
+        [disabled]="salvandoFamilia || carregandoFamilia"
         class="px-8 py-3 gradient-blue text-white rounded-xl font-semibold hover:opacity-90 transition-all duration-200 transform hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed"
       >
-        {{ salvandoFamilia ? 'Salvando...' : 'Cadastrar Família' }}
+        {{ salvandoFamilia ? 'Salvando...' : textoBotaoPrincipal }}
       </button>
     </div>
+  </div>
+</div>
+
+<div
+  *ngIf="carregandoFamilia"
+  class="fixed inset-0 bg-white/70 backdrop-blur-sm flex items-center justify-center z-[55]"
+>
+  <div class="bg-white rounded-2xl shadow-xl border border-gray-200 px-6 py-5 flex items-center gap-3 text-gray-700">
+    <svg
+      class="w-6 h-6 text-blue-600 animate-spin"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+      <path
+        class="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      ></path>
+    </svg>
+    <span class="font-semibold">Carregando família...</span>
   </div>
 </div>
 

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -201,7 +201,7 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   }
 
   private montarLinkFamilia(id: number): string {
-    const urlTree = this.router.createUrlTree(['/familias'], { queryParams: { familiaId: id } });
+    const urlTree = this.router.createUrlTree(['/familias', 'editar', id]);
     const url = this.router.serializeUrl(urlTree);
     if (typeof window !== 'undefined' && window.location) {
       return `${window.location.origin}${url}`;


### PR DESCRIPTION
## Resumo
- adiciona endpoints REST para consultar e atualizar famílias existentes
- adapta o serviço e o formulário Angular para carregar dados ao editar
- cobre a atualização com testes unitários no serviço de famílias

## Testes
- npm test (frontend)
- npm test (backend-java) *(falhou: package.json ausente)*
- mvn test


------
https://chatgpt.com/codex/tasks/task_e_68e0a9e4ef4c8328bb441ffac003e744