### PR TITLE
Restringe entrada de telefone dos membros

### DIFF
--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -828,48 +828,45 @@ export class NovaFamiliaComponent implements OnInit {
       return '';
     }
 
-    if (numeros.length <= 10) {
-      return numeros.replace(/(\d{0,2})(\d{0,4})(\d{0,4})/, (_, ddd, parte1, parte2) => {
-        let resultado = '';
-        if (ddd) {
-          resultado += `(${ddd}`;
-          if (ddd.length === 2) {
-            resultado += ') ';
-          }
-        }
-        if (parte1) {
-          resultado += parte1;
-        }
-        if (parte2) {
-          resultado += `-${parte2}`;
-        }
-        return resultado.trim();
-      });
+    const partes = numeros.match(/^(\d{0,2})(\d{0,1})(\d{0,4})(\d{0,4})$/);
+    if (!partes) {
+      return '';
     }
 
-    return numeros.replace(/(\d{0,2})(\d{0,5})(\d{0,4})/, (_, ddd, parte1, parte2) => {
-      let resultado = '';
-      if (ddd) {
-        resultado += `(${ddd}`;
-        if (ddd.length === 2) {
-          resultado += ') ';
-        }
+    const [, ddd, primeiroDigito, bloco1, bloco2] = partes;
+
+    let resultado = '';
+
+    if (ddd) {
+      resultado += `(${ddd}`;
+      if (ddd.length === 2) {
+        resultado += ') ';
       }
-      if (parte1) {
-        resultado += parte1;
+    }
+
+    if (primeiroDigito) {
+      resultado += primeiroDigito;
+      if (bloco1 || bloco2) {
+        resultado += ' ';
       }
-      if (parte2) {
-        resultado += `-${parte2}`;
-      }
-      return resultado.trim();
-    });
+    }
+
+    if (bloco1) {
+      resultado += bloco1;
+    }
+
+    if (bloco2) {
+      resultado += `-${bloco2}`;
+    }
+
+    return resultado.trim();
   }
 
   private obterTelefoneLimpo(telefone: string): string | null {
     if (!telefone) {
       return null;
     }
-    const numeros = telefone.replace(/\D/g, '');
+    const numeros = telefone.replace(/\D/g, '').slice(0, 11);
     return numeros ? numeros : null;
   }
 


### PR DESCRIPTION
## Summary
- aplica máscara de telefone que segue o formato (XX)X XXXX-XXXX e impede a digitação de dígitos extras
- limita os números encaminhados ao backend a, no máximo, 11 dígitos

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e0abfcf3c48328a71e9a18e9f1df7c