### PR TITLE
feat: implementar gestão de demandas familiares

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -17,6 +17,11 @@ const routes: Routes = [
     loadChildren: () => import('./modules/familias/familias.module').then(m => m.FamiliasModule)
   },
   {
+    path: 'demandas',
+    canActivate: [AuthGuard],
+    loadChildren: () => import('./modules/demandas/demandas.module').then(m => m.DemandasModule)
+  },
+  {
     path: 'configuracoes',
     canActivate: [AdminGuard],
     loadChildren: () => import('./modules/configuracoes/configuracoes.module').then(m => m.ConfiguracoesModule)

--- a/frontend/src/app/components/top-nav/top-nav.component.ts
+++ b/frontend/src/app/components/top-nav/top-nav.component.ts
@@ -80,6 +80,12 @@ export class TopNavComponent implements OnDestroy {
         description: 'Gestão de núcleos familiares',
         icon: 'M12 7a4 4 0 110 8 4 4 0 010-8zm0-5a6 6 0 016 6v1.26a8 8 0 014 6.91V21h-2v-4a4 4 0 00-4-4h-8a4 4 0 00-4 4v4H2v-4.83a',
         route: '/familias'
+      },
+      {
+        label: 'Demandas',
+        description: 'Fila de solicitações das famílias',
+        icon: 'M5 3a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V9.414A2 2 0 0020.414 8L15 2.586A2 2 0 0013.586 2H5zm7 1.414L19.586 12H12z',
+        route: '/demandas'
       }
     ];
 

--- a/frontend/src/app/modules/demandas/demandas.component.css
+++ b/frontend/src/app/modules/demandas/demandas.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/frontend/src/app/modules/demandas/demandas.component.html
+++ b/frontend/src/app/modules/demandas/demandas.component.html
@@ -1,0 +1,315 @@
+<div class="min-h-screen bg-gradient-to-br from-gray-50 via-white to-blue-50 pb-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10">
+    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6 mb-10">
+      <div>
+        <div class="inline-flex items-center px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold mb-3">
+          Fila de acompanhamentos
+        </div>
+        <h1 class="text-3xl font-bold text-gray-900 mb-2">Demandas das famílias</h1>
+        <p class="text-gray-600 max-w-2xl">
+          Cadastre e acompanhe as solicitações feitas pelos núcleos familiares, organizando por urgência e andamento.
+        </p>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full lg:w-auto">
+        <div class="bg-white rounded-2xl shadow-card border border-gray-100 p-4">
+          <div class="text-xs uppercase text-gray-500">Pendentes</div>
+          <div class="text-2xl font-bold text-amber-600">{{ resumoDemandas.pendentes }}</div>
+          <div class="text-[11px] text-gray-400">Aguardando início</div>
+        </div>
+        <div class="bg-white rounded-2xl shadow-card border border-gray-100 p-4">
+          <div class="text-xs uppercase text-gray-500">Em andamento</div>
+          <div class="text-2xl font-bold text-blue-600">{{ resumoDemandas.emAndamento }}</div>
+          <div class="text-[11px] text-gray-400">Em tratamento</div>
+        </div>
+        <div class="bg-white rounded-2xl shadow-card border border-gray-100 p-4">
+          <div class="text-xs uppercase text-gray-500">Concluídas</div>
+          <div class="text-2xl font-bold text-emerald-600">{{ resumoDemandas.concluidas }}</div>
+          <div class="text-[11px] text-gray-400">Finalizadas</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
+      <div class="xl:col-span-1">
+        <div class="bg-white rounded-3xl shadow-card border border-gray-100 p-7">
+          <div class="flex items-center gap-3 mb-6">
+            <div class="w-10 h-10 gradient-blue rounded-2xl flex items-center justify-center text-white">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+              </svg>
+            </div>
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900">Registrar nova demanda</h2>
+              <p class="text-sm text-gray-500">Associe a demanda a uma família e defina prioridade.</p>
+            </div>
+          </div>
+
+          <ng-container *ngIf="!erroFamilias; else erroCarregamento">
+            <form [formGroup]="formulario" (ngSubmit)="registrarDemanda()" class="space-y-5" autocomplete="off">
+              <div class="flex flex-col gap-2">
+                <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Família *</label>
+                <select
+                  formControlName="familiaId"
+                  class="px-4 py-3 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  [disabled]="carregandoFamilias"
+                >
+                  <option [ngValue]="null">Selecione a família</option>
+                  <ng-container *ngIf="familias.length > 0; else nenhumaFamilia">
+                    <option *ngFor="let familia of familias" [ngValue]="familia.id">
+                      {{ obterFamiliaNome(familia.id) }}
+                    </option>
+                  </ng-container>
+                </select>
+                <p *ngIf="carregandoFamilias" class="text-xs text-blue-600">Carregando famílias cadastradas...</p>
+                <p *ngIf="formulario.get('familiaId')?.touched && formulario.get('familiaId')?.invalid" class="text-xs text-red-500">
+                  Selecione a família responsável pela demanda.
+                </p>
+              </div>
+
+              <div class="flex flex-col gap-2">
+                <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Título da demanda *</label>
+                <input
+                  type="text"
+                  formControlName="titulo"
+                  placeholder="Ex: Cirurgia de joelho para Maria"
+                  class="px-4 py-3 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <p *ngIf="formulario.get('titulo')?.touched && formulario.get('titulo')?.invalid" class="text-xs text-red-500">
+                  Informe um título com pelo menos 3 caracteres.
+                </p>
+              </div>
+
+              <div class="flex flex-col gap-2">
+                <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Descrição</label>
+                <textarea
+                  rows="4"
+                  formControlName="descricao"
+                  placeholder="Detalhes adicionais sobre a necessidade, encaminhamentos ou contatos."
+                  class="px-4 py-3 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                ></textarea>
+              </div>
+
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div class="flex flex-col gap-2">
+                  <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Urgência *</label>
+                  <select
+                    formControlName="urgencia"
+                    class="px-4 py-3 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="Baixa">Baixa</option>
+                    <option value="Média">Média</option>
+                    <option value="Alta">Alta</option>
+                  </select>
+                </div>
+                <div class="flex flex-col gap-2">
+                  <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Data limite</label>
+                  <input
+                    type="date"
+                    formControlName="dataLimite"
+                    class="px-4 py-3 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                class="w-full px-5 py-3 rounded-xl gradient-blue text-white text-sm font-semibold shadow-md hover:opacity-90 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                [disabled]="formulario.invalid || carregandoFamilias"
+              >
+                {{ carregandoFamilias ? 'Carregando famílias...' : 'Adicionar demanda' }}
+              </button>
+            </form>
+          </ng-container>
+        </div>
+      </div>
+
+      <div class="xl:col-span-2 space-y-6">
+        <div class="bg-white rounded-3xl shadow-card border border-gray-100 p-7">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900">Demandas cadastradas</h2>
+              <p class="text-sm text-gray-500">Filtre por status, urgência ou busque pelo título.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-3 w-full lg:w-auto">
+              <input
+                type="text"
+                [(ngModel)]="filtroBusca"
+                (ngModelChange)="aplicarFiltros()"
+                placeholder="Buscar por título, família ou descrição"
+                class="md:col-span-2 px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              <select
+                [(ngModel)]="filtroStatus"
+                (ngModelChange)="aplicarFiltros()"
+                class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option [ngValue]="''">Todos os status</option>
+                <option value="Pendente">Pendentes</option>
+                <option value="Em andamento">Em andamento</option>
+                <option value="Concluída">Concluídas</option>
+              </select>
+              <select
+                [(ngModel)]="filtroUrgencia"
+                (ngModelChange)="aplicarFiltros()"
+                class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option [ngValue]="''">Todas as urgências</option>
+                <option value="Baixa">Baixa</option>
+                <option value="Média">Média</option>
+                <option value="Alta">Alta</option>
+              </select>
+            </div>
+            <button
+              type="button"
+              (click)="limparFiltros()"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-all"
+            >
+              Limpar filtros
+            </button>
+          </div>
+        </div>
+
+        <div *ngFor="let secao of secoes" class="bg-white rounded-3xl shadow-card border border-gray-100 p-7">
+          <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
+            <div class="flex items-center gap-4">
+              <div class="w-12 h-12 rounded-2xl bg-blue-50 flex items-center justify-center">
+                <svg class="w-6 h-6" [ngClass]="secao.cor" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path [attr.d]="secao.icone" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+                </svg>
+              </div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900">{{ secao.titulo }}</h3>
+                <p class="text-sm text-gray-500">{{ secao.descricao }}</p>
+              </div>
+            </div>
+            <div class="px-4 py-2 rounded-full bg-gray-100 text-gray-600 text-sm font-medium">
+              {{ secao.demandas.length }} demanda{{ secao.demandas.length === 1 ? '' : 's' }}
+            </div>
+          </div>
+
+          <ng-container *ngIf="secao.demandas.length > 0; else secaoVazia">
+            <div class="space-y-5">
+              <div *ngFor="let demanda of secao.demandas" class="border border-gray-100 rounded-2xl p-5 hover:border-blue-200 transition-all">
+                <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <div class="flex flex-wrap items-center gap-2">
+                      <h4 class="text-lg font-semibold text-gray-900">{{ demanda.titulo }}</h4>
+                      <span
+                        class="px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide"
+                        [ngClass]="{
+                          'bg-emerald-100 text-emerald-700': demanda.urgencia === 'Baixa',
+                          'bg-amber-100 text-amber-700': demanda.urgencia === 'Média',
+                          'bg-red-100 text-red-700': demanda.urgencia === 'Alta'
+                        }"
+                      >
+                        Urgência {{ demanda.urgencia }}
+                      </span>
+                      <span
+                        *ngIf="demanda.dataLimite"
+                        class="px-3 py-1 rounded-full text-xs font-medium"
+                        [ngClass]="{
+                          'bg-red-100 text-red-700': estaAtrasada(demanda),
+                          'bg-blue-50 text-blue-600': !estaAtrasada(demanda)
+                        }"
+                      >
+                        {{ estaAtrasada(demanda) ? 'Atrasada' : 'Data limite: ' + formatarData(demanda.dataLimite) }}
+                      </span>
+                      <span
+                        *ngIf="demanda.status === 'Concluída' && demanda.dataConclusao"
+                        class="px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-600"
+                      >
+                        Concluída em {{ formatarData(demanda.dataConclusao) }}
+                      </span>
+                    </div>
+                    <p class="text-sm text-gray-600 mt-2" *ngIf="demanda.descricao">{{ demanda.descricao }}</p>
+                  </div>
+                  <div class="text-sm text-gray-500 space-y-1">
+                    <div class="font-semibold text-gray-700">{{ demanda.familiaNome }}</div>
+                    <div>{{ demanda.endereco }}</div>
+                    <div class="text-xs text-gray-400">Registrada em {{ formatarData(demanda.dataCriacao) }}</div>
+                  </div>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-3 mt-4">
+                  <ng-container [ngSwitch]="secao.status">
+                    <ng-container *ngSwitchCase="'Pendente'">
+                      <button
+                        type="button"
+                        class="px-4 py-2 rounded-xl bg-blue-100 text-blue-700 text-sm font-medium hover:bg-blue-200 transition-colors"
+                        (click)="atualizarStatus(demanda, 'Em andamento')"
+                      >
+                        Iniciar atendimento
+                      </button>
+                      <button
+                        type="button"
+                        class="px-4 py-2 rounded-xl bg-emerald-100 text-emerald-700 text-sm font-medium hover:bg-emerald-200 transition-colors"
+                        (click)="atualizarStatus(demanda, 'Concluída')"
+                      >
+                        Marcar como concluída
+                      </button>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="'Em andamento'">
+                      <button
+                        type="button"
+                        class="px-4 py-2 rounded-xl bg-amber-100 text-amber-700 text-sm font-medium hover:bg-amber-200 transition-colors"
+                        (click)="atualizarStatus(demanda, 'Pendente')"
+                      >
+                        Voltar para pendente
+                      </button>
+                      <button
+                        type="button"
+                        class="px-4 py-2 rounded-xl bg-emerald-100 text-emerald-700 text-sm font-medium hover:bg-emerald-200 transition-colors"
+                        (click)="atualizarStatus(demanda, 'Concluída')"
+                      >
+                        Concluir atendimento
+                      </button>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="'Concluída'">
+                      <button
+                        type="button"
+                        class="px-4 py-2 rounded-xl bg-blue-100 text-blue-700 text-sm font-medium hover:bg-blue-200 transition-colors"
+                        (click)="atualizarStatus(demanda, 'Pendente')"
+                      >
+                        Reabrir demanda
+                      </button>
+                    </ng-container>
+                  </ng-container>
+                  <button
+                    type="button"
+                    class="px-4 py-2 rounded-xl border border-red-200 text-sm font-medium text-red-600 hover:bg-red-50 transition-colors"
+                    (click)="removerDemanda(demanda)"
+                  >
+                    Remover
+                  </button>
+                </div>
+              </div>
+            </div>
+          </ng-container>
+        </div>
+
+        <div
+          *ngIf="semDemandasFiltradas"
+          class="bg-white rounded-3xl shadow-card border border-dashed border-gray-200 p-12 text-center text-gray-500"
+        >
+          Nenhuma demanda encontrada com os filtros atuais.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<ng-template #erroCarregamento>
+  <div class="p-6 bg-red-50 rounded-2xl border border-red-100 text-sm text-red-600">
+    {{ erroFamilias }}
+  </div>
+</ng-template>
+
+<ng-template #nenhumaFamilia>
+  <option disabled>Nenhuma família disponível</option>
+</ng-template>
+
+<ng-template #secaoVazia>
+  <div class="border border-dashed border-gray-200 rounded-2xl p-8 text-center text-sm text-gray-500">
+    Nenhuma demanda neste estágio.
+  </div>
+</ng-template>

--- a/frontend/src/app/modules/demandas/demandas.component.ts
+++ b/frontend/src/app/modules/demandas/demandas.component.ts
@@ -1,0 +1,294 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Subject, takeUntil } from 'rxjs';
+import { FamiliasService, FamiliaResponse } from '../familias/familias.service';
+import {
+  CriarDemandaPayload,
+  Demanda,
+  DemandaStatus,
+  DemandaUrgencia,
+  DemandasService
+} from '../shared/services/demandas.service';
+import { NotificationService } from '../shared/services/notification.service';
+
+interface DemandaDetalhada extends Demanda {
+  familiaNome: string;
+  responsavel: string;
+  endereco: string;
+}
+
+interface SecaoDemandas {
+  titulo: string;
+  descricao: string;
+  icone: string;
+  cor: string;
+  status: DemandaStatus;
+  demandas: DemandaDetalhada[];
+}
+
+@Component({
+  standalone: false,
+  selector: 'app-demandas',
+  templateUrl: './demandas.component.html',
+  styleUrls: ['./demandas.component.css']
+})
+export class DemandasComponent implements OnInit, OnDestroy {
+  formulario: FormGroup;
+  familias: FamiliaResponse[] = [];
+  carregandoFamilias = false;
+  erroFamilias = '';
+  resumoDemandas = {
+    pendentes: 0,
+    emAndamento: 0,
+    concluidas: 0
+  };
+  filtroStatus: '' | DemandaStatus = '';
+  filtroUrgencia: '' | DemandaUrgencia = '';
+  filtroBusca = '';
+  secoes: SecaoDemandas[] = [];
+  semDemandasFiltradas = false;
+  private todasDemandas: Demanda[] = [];
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly familiasService: FamiliasService,
+    private readonly demandasService: DemandasService,
+    private readonly notificationService: NotificationService
+  ) {
+    this.formulario = this.fb.group({
+      familiaId: [null, Validators.required],
+      titulo: ['', [Validators.required, Validators.minLength(3)]],
+      descricao: [''],
+      urgencia: ['Média', Validators.required],
+      dataLimite: ['']
+    });
+  }
+
+  ngOnInit(): void {
+    this.carregarFamilias();
+    this.demandasService
+      .observarDemandas()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(demandas => {
+        this.todasDemandas = demandas;
+        this.atualizarResumo();
+        this.recalcularSecoes();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  registrarDemanda(): void {
+    if (this.formulario.invalid) {
+      this.formulario.markAllAsTouched();
+      return;
+    }
+
+    const valores = this.formulario.value as {
+      familiaId: number;
+      titulo: string;
+      descricao: string;
+      urgencia: DemandaUrgencia;
+      dataLimite: string;
+    };
+
+    const payload: CriarDemandaPayload = {
+      familiaId: valores.familiaId,
+      titulo: valores.titulo,
+      descricao: valores.descricao || '',
+      urgencia: valores.urgencia,
+      dataLimite: valores.dataLimite ? valores.dataLimite : null
+    };
+
+    this.demandasService.criarDemanda(payload);
+    this.notificationService.showSuccess('Demanda registrada', 'A demanda foi adicionada à fila de acompanhamentos.');
+    this.formulario.reset({
+      familiaId: null,
+      titulo: '',
+      descricao: '',
+      urgencia: 'Média',
+      dataLimite: ''
+    });
+  }
+
+  aplicarFiltros(): void {
+    this.recalcularSecoes();
+  }
+
+  limparFiltros(): void {
+    this.filtroStatus = '';
+    this.filtroUrgencia = '';
+    this.filtroBusca = '';
+    this.recalcularSecoes();
+  }
+
+  formatarData(data: string | null): string {
+    if (!data) {
+      return 'Sem data limite';
+    }
+    const parsed = new Date(data);
+    if (Number.isNaN(parsed.getTime())) {
+      return 'Data inválida';
+    }
+    return parsed.toLocaleDateString();
+  }
+
+  estaAtrasada(demanda: DemandaDetalhada): boolean {
+    if (!demanda.dataLimite || demanda.status === 'Concluída') {
+      return false;
+    }
+    const limite = new Date(demanda.dataLimite);
+    const hoje = new Date();
+    limite.setHours(23, 59, 59, 999);
+    return limite.getTime() < hoje.getTime();
+  }
+
+  atualizarStatus(demanda: DemandaDetalhada, status: DemandaStatus): void {
+    if (demanda.status === status) {
+      return;
+    }
+    this.demandasService.atualizarDemanda(demanda.id, { status });
+    const mensagem =
+      status === 'Concluída'
+        ? 'Demanda marcada como concluída.'
+        : status === 'Em andamento'
+          ? 'Demanda marcada como em andamento.'
+          : 'Demanda reaberta como pendente.';
+    this.notificationService.showSuccess('Status atualizado', mensagem);
+  }
+
+  removerDemanda(demanda: DemandaDetalhada): void {
+    this.demandasService.removerDemanda(demanda.id);
+    this.notificationService.showInfo('Demanda removida', 'O registro foi retirado da fila.');
+  }
+
+  obterFamiliaNome(familiaId: number): string {
+    const familia = this.familias.find(item => item.id === familiaId);
+    if (!familia) {
+      return 'Família não encontrada';
+    }
+    return `Família de ${this.obterResponsavel(familia)}`;
+  }
+
+  private carregarFamilias(): void {
+    this.carregandoFamilias = true;
+    this.erroFamilias = '';
+    this.familiasService.listarTodasFamilias().pipe(takeUntil(this.destroy$)).subscribe({
+      next: familias => {
+        this.familias = familias;
+        this.carregandoFamilias = false;
+        this.recalcularSecoes();
+      },
+      error: erro => {
+        console.error('Erro ao carregar famílias para demandas', erro);
+        this.erroFamilias = 'Não foi possível carregar a lista de famílias.';
+        this.carregandoFamilias = false;
+      }
+    });
+  }
+
+  private obterResponsavel(familia: FamiliaResponse): string {
+    const responsavel = familia.membros.find(membro => membro.responsavelPrincipal);
+    return responsavel?.nomeCompleto || 'Responsável não informado';
+  }
+
+  private construirDemandaDetalhada(demanda: Demanda): DemandaDetalhada {
+    const familia = this.familias.find(item => item.id === demanda.familiaId);
+    if (!familia) {
+      return {
+        ...demanda,
+        familiaNome: 'Família não encontrada',
+        responsavel: 'Responsável não disponível',
+        endereco: 'Endereço não disponível'
+      };
+    }
+    const responsavel = this.obterResponsavel(familia);
+    const endereco = familia.enderecoDetalhado
+      ? `${familia.enderecoDetalhado.rua}, ${familia.enderecoDetalhado.numero || 's/ nº'} • ${familia.enderecoDetalhado.cidade}/${familia.enderecoDetalhado.uf}`
+      : 'Endereço não informado';
+    return {
+      ...demanda,
+      familiaNome: `Família de ${responsavel}`,
+      responsavel,
+      endereco
+    };
+  }
+
+  private filtrarDemandas(): DemandaDetalhada[] {
+    const buscas = this.filtroBusca.trim().toLowerCase();
+    return this.todasDemandas
+      .map(demanda => this.construirDemandaDetalhada(demanda))
+      .filter(demanda => {
+        if (this.filtroStatus && demanda.status !== this.filtroStatus) {
+          return false;
+        }
+        if (this.filtroUrgencia && demanda.urgencia !== this.filtroUrgencia) {
+          return false;
+        }
+        if (!buscas) {
+          return true;
+        }
+        return (
+          demanda.titulo.toLowerCase().includes(buscas) ||
+          demanda.descricao.toLowerCase().includes(buscas) ||
+          demanda.familiaNome.toLowerCase().includes(buscas)
+        );
+      });
+  }
+
+  private recalcularSecoes(): void {
+    const filtradas = this.filtrarDemandas();
+    const mapearSecao = (status: DemandaStatus): SecaoDemandas => {
+      const propriedades = this.propriedadesStatus(status);
+      return {
+        ...propriedades,
+        demandas: filtradas.filter(demanda => demanda.status === status)
+      };
+    };
+    this.secoes = [mapearSecao('Pendente'), mapearSecao('Em andamento'), mapearSecao('Concluída')];
+    this.semDemandasFiltradas = filtradas.length === 0;
+  }
+
+  private propriedadesStatus(status: DemandaStatus): Omit<SecaoDemandas, 'demandas'> {
+    if (status === 'Pendente') {
+      return {
+        titulo: 'Pendentes',
+        descricao: 'Demandas aguardando atendimento inicial.',
+        icone: 'M12 8c1.657 0 3-1.79 3-4S13.657 0 12 0 9 1.79 9 4s1.343 4 3 4zm0 2c-2.21 0-4 1.79-4 4v8h8v-8c0-2.21-1.79-4-4-4z',
+        cor: 'text-amber-600',
+        status
+      };
+    }
+    if (status === 'Em andamento') {
+      return {
+        titulo: 'Em andamento',
+        descricao: 'Demandas que estão sendo tratadas.',
+        icone: 'M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm-1-15h2v6h-2zm0 8h2v2h-2z',
+        cor: 'text-blue-600',
+        status
+      };
+    }
+    return {
+      titulo: 'Concluídas',
+      descricao: 'Demandas finalizadas com sucesso.',
+      icone: 'M9 16.17L4.83 12 3.41 13.41 9 19l12-12-1.41-1.41z',
+      cor: 'text-emerald-600',
+      status
+    };
+  }
+
+  private atualizarResumo(): void {
+    const pendentes = this.todasDemandas.filter(demanda => demanda.status === 'Pendente').length;
+    const andamento = this.todasDemandas.filter(demanda => demanda.status === 'Em andamento').length;
+    const concluidas = this.todasDemandas.filter(demanda => demanda.status === 'Concluída').length;
+    this.resumoDemandas = {
+      pendentes,
+      emAndamento: andamento,
+      concluidas
+    };
+  }
+}

--- a/frontend/src/app/modules/demandas/demandas.module.ts
+++ b/frontend/src/app/modules/demandas/demandas.module.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DemandasComponent } from './demandas.component';
+
+const routes: Routes = [
+  { path: '', component: DemandasComponent }
+];
+
+@NgModule({
+  declarations: [DemandasComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule.forChild(routes)]
+})
+export class DemandasModule {}

--- a/frontend/src/app/modules/familias/familias.component.html
+++ b/frontend/src/app/modules/familias/familias.component.html
@@ -263,9 +263,20 @@
                         {{ obterIniciais(obterResponsavel(familia)) }}
                       </div>
                       <div>
-                        <h2 class="text-lg font-semibold text-gray-900 mb-1">
-                          Família de {{ obterResponsavel(familia) }}
-                        </h2>
+                        <div class="flex flex-wrap items-center gap-2 mb-1">
+                          <h2 class="text-lg font-semibold text-gray-900">
+                            Família de {{ obterResponsavel(familia) }}
+                          </h2>
+                          <span
+                            *ngIf="temDemandasPendentes(familia)"
+                            class="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-amber-100 text-amber-700 text-xs font-semibold"
+                          >
+                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                              <path d="M10 2a1 1 0 01.894.553l7 14A1 1 0 0117 18H3a1 1 0 01-.894-1.447l7-14A1 1 0 0110 2zm0 4a.75.75 0 00-.75.75v4.5a.75.75 0 001.5 0v-4.5A.75.75 0 0010 6zm0 8a1 1 0 100 2 1 1 0 000-2z" />
+                            </svg>
+                            {{ contarDemandasPendentes(familia) }} demanda{{ contarDemandasPendentes(familia) === 1 ? '' : 's' }} pendente{{ contarDemandasPendentes(familia) === 1 ? '' : 's' }}
+                          </span>
+                        </div>
                         <div class="text-sm text-gray-500 flex flex-wrap items-center gap-2">
                           <span *ngIf="familia.enderecoDetalhado?.bairro">{{ familia.enderecoDetalhado.bairro }}</span>
                           <span *ngIf="familia.enderecoDetalhado?.regiao">• Região {{ familia.enderecoDetalhado.regiao }}</span>

--- a/frontend/src/app/modules/familias/familias.component.ts
+++ b/frontend/src/app/modules/familias/familias.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { forkJoin, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Subject, forkJoin, of } from 'rxjs';
+import { catchError, takeUntil } from 'rxjs/operators';
 import {
   FamiliasService,
   FamiliaFiltro,
@@ -13,6 +13,7 @@ import {
   Cidade,
   Regiao
 } from '../shared/services/localidades.service';
+import { DemandasService, Demanda } from '../shared/services/demandas.service';
 
 type RegiaoFiltro = Regiao & { cidadeId: number; cidadeNome: string };
 
@@ -24,7 +25,7 @@ type RegiaoFiltro = Regiao & { cidadeId: number; cidadeNome: string };
   templateUrl: './familias.component.html',
   styleUrls: ['./familias.component.css']
 })
-export class FamiliasComponent implements OnInit {
+export class FamiliasComponent implements OnInit, OnDestroy {
   destaques: { titulo: string; valor: string; variacao: string; descricao: string }[] = [];
   familias: FamiliaResponse[] = [];
   carregando = false;
@@ -46,13 +47,16 @@ export class FamiliasComponent implements OnInit {
   mostrarFiltrosAvancados = false;
   private todasRegioes: RegiaoFiltro[] = [];
   private readonly regioesPorCidade = new Map<number, RegiaoFiltro[]>();
+  private readonly destroy$ = new Subject<void>();
+  private demandasAbertas = new Map<number, number>();
 
   constructor(
     private readonly familiasService: FamiliasService,
     private readonly route: ActivatedRoute,
     private readonly fb: FormBuilder,
     private readonly localidadesService: LocalidadesService,
-    private readonly router: Router
+    private readonly router: Router,
+    private readonly demandasService: DemandasService
   ) {
     this.filtroForm = this.fb.group({
       cidadeId: [null],
@@ -70,6 +74,11 @@ export class FamiliasComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.demandasService
+      .observarDemandas()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(demandas => this.atualizarDemandasAbertas(demandas));
+
     const familiaIdParam = this.route.snapshot.queryParamMap.get('familiaId');
     if (familiaIdParam) {
       const id = Number(familiaIdParam);
@@ -89,6 +98,11 @@ export class FamiliasComponent implements OnInit {
         this.buscarFamilias();
       }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   alternarFiltrosAvancados(): void {
@@ -225,6 +239,14 @@ export class FamiliasComponent implements OnInit {
     return responsavel.telefone;
   }
 
+  contarDemandasPendentes(familia: FamiliaResponse): number {
+    return this.demandasAbertas.get(familia.id) ?? 0;
+  }
+
+  temDemandasPendentes(familia: FamiliaResponse): boolean {
+    return this.contarDemandasPendentes(familia) > 0;
+  }
+
   obterTotalMembros(familia: FamiliaResponse): number {
     return familia.membros.length;
   }
@@ -304,6 +326,18 @@ export class FamiliasComponent implements OnInit {
       this.atualizarTodasRegioesDisponiveis();
       this.regioes = this.todasRegioes;
     });
+  }
+
+  private atualizarDemandasAbertas(demandas: Demanda[]): void {
+    const mapa = new Map<number, number>();
+    demandas.forEach(demanda => {
+      if (demanda.status === 'Concluída') {
+        return;
+      }
+      const total = mapa.get(demanda.familiaId) ?? 0;
+      mapa.set(demanda.familiaId, total + 1);
+    });
+    this.demandasAbertas = mapa;
   }
 
   private carregarRegioesPorCidade(cidadeId: number): void {

--- a/frontend/src/app/modules/shared/services/demandas.service.ts
+++ b/frontend/src/app/modules/shared/services/demandas.service.ts
@@ -1,0 +1,156 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+export type DemandaUrgencia = 'Baixa' | 'Média' | 'Alta';
+export type DemandaStatus = 'Pendente' | 'Em andamento' | 'Concluída';
+
+export interface Demanda {
+  id: string;
+  familiaId: number;
+  titulo: string;
+  descricao: string;
+  urgencia: DemandaUrgencia;
+  status: DemandaStatus;
+  dataCriacao: string;
+  dataLimite: string | null;
+  dataConclusao: string | null;
+}
+
+export interface CriarDemandaPayload {
+  familiaId: number;
+  titulo: string;
+  descricao: string;
+  urgencia: DemandaUrgencia;
+  dataLimite: string | null;
+}
+
+const STORAGE_KEY = 'gestor-politico-demandas';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DemandasService {
+  private readonly demandasSubject: BehaviorSubject<Demanda[]>;
+  private memoria: Demanda[] = [];
+
+  constructor() {
+    const carregadas = this.carregarDemandas();
+    this.memoria = carregadas;
+    this.demandasSubject = new BehaviorSubject<Demanda[]>(carregadas);
+  }
+
+  observarDemandas(): Observable<Demanda[]> {
+    return this.demandasSubject.asObservable();
+  }
+
+  obterDemandasAtuais(): Demanda[] {
+    return this.demandasSubject.value;
+  }
+
+  criarDemanda(payload: CriarDemandaPayload): Demanda {
+    const novaDemanda: Demanda = {
+      id: this.gerarId(),
+      familiaId: payload.familiaId,
+      titulo: payload.titulo.trim(),
+      descricao: payload.descricao.trim(),
+      urgencia: payload.urgencia,
+      status: 'Pendente',
+      dataCriacao: new Date().toISOString(),
+      dataLimite: payload.dataLimite,
+      dataConclusao: null
+    };
+
+    const demandas = [...this.obterDemandasAtuais(), novaDemanda];
+    this.persistir(demandas);
+    return novaDemanda;
+  }
+
+  atualizarDemanda(id: string, alteracoes: Partial<Omit<Demanda, 'id' | 'familiaId' | 'dataCriacao'>>): Demanda | null {
+    const demandas = this.obterDemandasAtuais();
+    const indice = demandas.findIndex(demanda => demanda.id === id);
+    if (indice === -1) {
+      return null;
+    }
+
+    const atual = demandas[indice];
+    const atualizado: Demanda = {
+      ...atual,
+      ...alteracoes
+    };
+
+    if (alteracoes.status) {
+      if (alteracoes.status === 'Concluída') {
+        atualizado.dataConclusao = alteracoes.dataConclusao ?? new Date().toISOString();
+      } else {
+        atualizado.dataConclusao = null;
+      }
+    }
+
+    const copia = [...demandas];
+    copia[indice] = atualizado;
+    this.persistir(copia);
+    return atualizado;
+  }
+
+  removerDemanda(id: string): void {
+    const filtradas = this.obterDemandasAtuais().filter(demanda => demanda.id !== id);
+    this.persistir(filtradas);
+  }
+
+  contarAbertasPorFamilia(familiaId: number): number {
+    return this.obterDemandasAtuais().filter(demanda => demanda.familiaId === familiaId && demanda.status !== 'Concluída').length;
+  }
+
+  listarPorFamilia(familiaId: number): Demanda[] {
+    return this.obterDemandasAtuais().filter(demanda => demanda.familiaId === familiaId);
+  }
+
+  private persistir(demandas: Demanda[]): void {
+    this.memoria = demandas;
+    if (this.storageDisponivel()) {
+      try {
+        const texto = JSON.stringify(demandas);
+        window.localStorage.setItem(STORAGE_KEY, texto);
+      } catch (erro) {
+        console.warn('Não foi possível salvar as demandas no armazenamento local.', erro);
+      }
+    }
+    this.demandasSubject.next(demandas);
+  }
+
+  private carregarDemandas(): Demanda[] {
+    if (this.storageDisponivel()) {
+      try {
+        const texto = window.localStorage.getItem(STORAGE_KEY);
+        if (!texto) {
+          return [];
+        }
+        const parsed = JSON.parse(texto) as Demanda[];
+        if (Array.isArray(parsed)) {
+          return parsed.map(demanda => ({
+            ...demanda,
+            descricao: demanda.descricao || '',
+            dataLimite: demanda.dataLimite ?? null,
+            dataConclusao: demanda.dataConclusao ?? null
+          }));
+        }
+      } catch (erro) {
+        console.warn('Não foi possível carregar as demandas salvas.', erro);
+      }
+    }
+    return [...this.memoria];
+  }
+
+  private storageDisponivel(): boolean {
+    return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+  }
+
+  private gerarId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    const random = Math.random().toString(36).substring(2, 10);
+    const timestamp = Date.now().toString(36);
+    return `${timestamp}-${random}`;
+  }
+}


### PR DESCRIPTION
## Resumo
- cria o módulo **Demandas** com formulário, filtros e cards para acompanhar solicitações por urgência e status
- adiciona `DemandasService` com persistência local para registrar, atualizar e remover demandas das famílias
- exibe o indicador de pendências na lista de famílias e inclui acesso dedicado no menu principal

## Testes
- npm test -- --watch=false
- npm test *(backend-java – falha: arquivo package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68e0aa913d0c83289812c7e166b68490