### PR TITLE
Adicionar modal de busca de famílias no registro de demandas

### DIFF
--- a/frontend/src/app/modules/demandas/demandas.component.html
+++ b/frontend/src/app/modules/demandas/demandas.component.html
@@ -48,18 +48,26 @@
             <form [formGroup]="formulario" (ngSubmit)="registrarDemanda()" class="space-y-5" autocomplete="off">
               <div class="flex flex-col gap-2">
                 <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Família *</label>
-                <select
-                  formControlName="familiaId"
-                  class="px-4 py-3 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  [disabled]="carregandoFamilias"
-                >
-                  <option [ngValue]="null">Selecione a família</option>
-                  <ng-container *ngIf="familias.length > 0; else nenhumaFamilia">
-                    <option *ngFor="let familia of familias" [ngValue]="familia.id">
-                      {{ obterFamiliaNome(familia.id) }}
-                    </option>
-                  </ng-container>
-                </select>
+                <div class="flex items-center gap-3">
+                  <input
+                    type="text"
+                    class="flex-1 px-4 py-3 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    [value]="familiaSelecionada ? obterFamiliaNome(familiaSelecionada.id) : ''"
+                    placeholder="Selecione a família"
+                    readonly
+                    [class.bg-gray-100]="carregandoFamilias"
+                  />
+                  <button
+                    type="button"
+                    class="w-11 h-11 rounded-xl border border-gray-200 text-gray-600 hover:bg-gray-50 transition-all flex items-center justify-center"
+                    (click)="abrirBuscaFamilias()"
+                    [disabled]="carregandoFamilias"
+                  >
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
+                    </svg>
+                  </button>
+                </div>
                 <p *ngIf="carregandoFamilias" class="text-xs text-blue-600">Carregando famílias cadastradas...</p>
                 <p *ngIf="formulario.get('familiaId')?.touched && formulario.get('familiaId')?.invalid" class="text-xs text-red-500">
                   Selecione a família responsável pela demanda.
@@ -296,6 +304,221 @@
       </div>
     </div>
   </div>
+  <div
+    *ngIf="mostrarModalSelecionarFamilia"
+    class="fixed inset-0 z-50 flex items-center justify-center"
+  >
+    <div
+      class="absolute inset-0 bg-gray-900/50"
+      (click)="fecharBuscaFamilias()"
+    ></div>
+    <div class="relative bg-white rounded-3xl shadow-2xl border border-gray-100 max-w-5xl w-full mx-4 max-h-[90vh] flex flex-col">
+      <div class="flex items-center justify-between px-6 py-5 border-b border-gray-100">
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900">Selecionar família</h3>
+          <p class="text-sm text-gray-500">Use os filtros avançados para localizar rapidamente o núcleo desejado.</p>
+        </div>
+        <button
+          type="button"
+          class="w-10 h-10 rounded-xl border border-gray-200 text-gray-500 hover:bg-gray-50 transition-all flex items-center justify-center"
+          (click)="fecharBuscaFamilias()"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <form
+        [formGroup]="filtroFamiliasForm"
+        (ngSubmit)="aplicarFiltroFamiliasBusca()"
+        class="px-6 py-5 border-b border-gray-100 space-y-4"
+      >
+        <div class="flex flex-col gap-3 lg:flex-row lg:items-end">
+          <div class="flex-1 flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Busca livre</label>
+            <input
+              type="text"
+              formControlName="termo"
+              placeholder="Digite nome, endereço ou palavra-chave"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div class="flex flex-wrap items-center gap-3 lg:justify-end">
+            <button
+              type="button"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-white transition-all"
+              (click)="alternarFiltrosFamilias()"
+            >
+              {{ mostrarFiltrosAvancadosFamilias ? 'Ocultar filtros' : 'Filtro avançado' }}
+            </button>
+            <button
+              type="button"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-white transition-all"
+              (click)="limparFiltroFamiliasBusca()"
+            >
+              Limpar filtros
+            </button>
+            <button
+              type="submit"
+              class="px-5 py-2.5 rounded-xl gradient-blue text-white text-sm font-semibold shadow-md hover:opacity-90 transition-all"
+            >
+              Aplicar filtros
+            </button>
+          </div>
+        </div>
+
+        <div
+          *ngIf="mostrarFiltrosAvancadosFamilias"
+          class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4"
+        >
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Cidade</label>
+            <select
+              formControlName="cidade"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todas as cidades</option>
+              <option *ngFor="let cidade of cidadesDisponiveis" [value]="cidade">{{ cidade }}</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Região</label>
+            <select
+              formControlName="regiao"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todas as regiões</option>
+              <option *ngFor="let regiao of regioesDisponiveis" [value]="regiao">{{ regiao }}</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Responsável</label>
+            <input
+              type="text"
+              formControlName="responsavel"
+              placeholder="Nome do responsável"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Probabilidade de voto</label>
+            <select
+              formControlName="probabilidadeVoto"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Todas</option>
+              <option *ngFor="let probabilidade of probabilidadesVoto" [value]="probabilidade">{{ probabilidade }}</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Data inicial</label>
+            <input
+              type="date"
+              formControlName="dataInicio"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Data final</label>
+            <input
+              type="date"
+              formControlName="dataFim"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Bairro</label>
+            <input
+              type="text"
+              formControlName="bairro"
+              placeholder="Nome do bairro"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Rua</label>
+            <input
+              type="text"
+              formControlName="rua"
+              placeholder="Logradouro"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Número</label>
+            <input
+              type="text"
+              formControlName="numero"
+              placeholder="Número"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label class="text-xs font-semibold text-gray-600 uppercase tracking-wide">CEP</label>
+            <input
+              type="text"
+              formControlName="cep"
+              placeholder="CEP"
+              class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      </form>
+
+      <div class="flex-1 overflow-y-auto">
+        <ng-container *ngIf="familiasFiltradasBusca.length > 0; else semFamiliasFiltradas">
+          <ul class="divide-y divide-gray-100">
+            <li
+              *ngFor="let familia of familiasFiltradasBusca"
+              class="px-6 py-5 hover:bg-gray-50 transition-all flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+            >
+              <div>
+                <div class="flex items-center gap-3">
+                  <div class="w-10 h-10 rounded-2xl bg-blue-50 text-blue-600 font-semibold flex items-center justify-center">
+                    {{ obterIniciaisFamilia(familia) }}
+                  </div>
+                  <div>
+                    <div class="text-sm font-semibold text-gray-900">{{ obterFamiliaNome(familia.id) }}</div>
+                    <div class="text-xs text-gray-500">{{ obterEnderecoResumido(familia) }}</div>
+                  </div>
+                </div>
+                <div class="mt-3 text-xs text-gray-500 flex flex-wrap gap-x-4 gap-y-1">
+                  <span>Responsável: {{ obterResponsavel(familia) }}</span>
+                  <span>Probabilidade: {{ obterProbabilidadeFamilia(familia) }}</span>
+                  <span>Registrada em: {{ obterDataCadastroFamilia(familia.criadoEm) }}</span>
+                </div>
+              </div>
+              <div class="flex items-center gap-3">
+                <button
+                  type="button"
+                  class="px-4 py-2 rounded-xl gradient-blue text-white text-sm font-semibold shadow-md hover:opacity-90 transition-all"
+                  (click)="selecionarFamilia(familia)"
+                >
+                  Selecionar família
+                </button>
+              </div>
+            </li>
+          </ul>
+        </ng-container>
+      </div>
+
+      <div class="px-6 py-4 border-t border-gray-100 bg-gray-50 text-xs text-gray-500">
+        Exibindo {{ familiasFiltradasBusca.length }} família{{ familiasFiltradasBusca.length === 1 ? '' : 's' }} encontrada{{
+          familiasFiltradasBusca.length === 1 ? '' : 's'
+        }}.
+      </div>
+    </div>
+  </div>
 </div>
 
 <ng-template #erroCarregamento>
@@ -304,12 +527,14 @@
   </div>
 </ng-template>
 
-<ng-template #nenhumaFamilia>
-  <option disabled>Nenhuma família disponível</option>
-</ng-template>
-
 <ng-template #secaoVazia>
   <div class="border border-dashed border-gray-200 rounded-2xl p-8 text-center text-sm text-gray-500">
     Nenhuma demanda neste estágio.
+  </div>
+</ng-template>
+
+<ng-template #semFamiliasFiltradas>
+  <div class="px-6 py-10 text-center text-sm text-gray-500">
+    Nenhuma família encontrada com os filtros informados.
   </div>
 </ng-template>


### PR DESCRIPTION
## Resumo
- substituir o seletor simples de família por um campo com botão de busca
- criar modal com filtros avançados semelhantes à tela de famílias para localizar famílias
- adicionar utilitários de filtragem e metadados para apresentar informações resumidas antes da seleção

## Testes
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e1e27f1d80832883d6305804c16096