### PR TITLE
Adicionar atalho para demandas da família

### DIFF
--- a/frontend/src/app/modules/demandas/demandas.component.html
+++ b/frontend/src/app/modules/demandas/demandas.component.html
@@ -167,6 +167,25 @@
               Limpar filtros
             </button>
           </div>
+          <div
+            *ngIf="filtroFamiliaId !== null"
+            class="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 rounded-2xl border border-blue-100 bg-blue-50 text-blue-700"
+          >
+            <div class="text-sm">
+              <span class="font-semibold">Filtrando por família:</span>
+              <span>{{ obterFamiliaNome(filtroFamiliaId) }}</span>
+            </div>
+            <button
+              type="button"
+              (click)="removerFiltroFamilia()"
+              class="flex items-center gap-2 text-sm font-semibold text-blue-600 hover:underline"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+              </svg>
+              Remover filtro
+            </button>
+          </div>
         </div>
 
         <div *ngFor="let secao of secoes" class="bg-white rounded-3xl shadow-card border border-gray-100 p-7">

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -28,7 +28,18 @@
           <p class="text-sm text-gray-600">{{ descricaoPagina }}</p>
         </div>
       </div>
-      <div class="flex items-center">
+      <div class="flex items-center space-x-3">
+        <button
+          *ngIf="modoEdicao && familiaIdEdicao"
+          type="button"
+          (click)="abrirDemandasFamilia()"
+          class="px-4 py-2 bg-blue-100 text-blue-700 rounded-xl font-medium hover:bg-blue-200 transition-colors flex items-center gap-2"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M3 12h18M3 17h12"></path>
+          </svg>
+          Ver demandas
+        </button>
         <button
           type="button"
           (click)="cancelarCadastro()"

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.ts
@@ -319,6 +319,14 @@ export class NovaFamiliaComponent implements OnInit {
     this.router.navigate(['/familias']);
   }
 
+  abrirDemandasFamilia(): void {
+    if (!this.familiaIdEdicao) {
+      return;
+    }
+
+    this.router.navigate(['/demandas'], { queryParams: { familiaId: this.familiaIdEdicao } });
+  }
+
   cancelarCadastro(): void {
     this.router.navigate(['/familias']);
   }


### PR DESCRIPTION
## Summary
- adiciona botão na edição de família para abrir diretamente a tela de demandas com o núcleo selecionado
- permite que a tela de demandas receba o parâmetro de família, aplique o filtro correspondente e mostre um aviso visual com opção de limpar
- pré-preenche o formulário de nova demanda com a família vinda do atalho quando disponível

## Testing
- npm test -- --watch=false (frontend)
- npm test -- --watch=false (backend-java) *(falha: diretório sem package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e2bb80fc832896a9a1f0dcd3b700