### PR TITLE
Corrige exibição de famílias no mapa

### DIFF
--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -145,12 +145,10 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
       return;
     }
 
-    const coordenadas: L.LatLngExpression[] = [];
-    this.familiasLocalizadas.forEach(familia => {
-      const marcador = this.criarMarcador(familia);
-      marcador.addTo(this.camadaMarcadores as L.LayerGroup);
-      coordenadas.push([familia.latitudeMapa, familia.longitudeMapa]);
-    });
+    const coordenadas: L.LatLngExpression[] = this.familiasLocalizadas.map(familia => [
+      familia.latitudeMapa,
+      familia.longitudeMapa
+    ]);
 
 
     if (this.exibirMapaDeCalor) {


### PR DESCRIPTION
## Resumo
- evita adicionar marcadores em uma camada inexistente ao preparar as coordenadas do mapa
- garante que apenas a lista de coordenadas seja usada antes da criação das camadas

## Testes
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e1e354ead08328bd20b5d5e97e954d