### PR TITLE
Corrige posicionamento do marcador de família no mapa

### DIFF
--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -41,8 +41,8 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
     `,
     className: 'familia-marker',
     iconSize: [48, 48],
-    iconAnchor: [24, 48],
-    popupAnchor: [0, -42]
+    iconAnchor: [24, 24],
+    popupAnchor: [0, -32]
   });
 
   constructor(


### PR DESCRIPTION
## Resumo
- ajusta a âncora do ícone de família para manter o marcador alinhado ao endereço independente do zoom
- atualiza o ponto de ancoragem do popup para acompanhar a nova referência do ícone

## Testes
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e1ea1abb648328994622a594a8557d