### PR TITLE
Ajusta alinhamento dos marcadores de famílias no mapa

### DIFF
--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.css
@@ -123,16 +123,29 @@
 .familia-marker {
   position: relative;
   width: 48px;
-  height: 48px;
+  height: 64px;
+}
+
+.familia-marker__shadow {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 28px;
+  height: 12px;
+  transform: translateX(-50%);
+  background: radial-gradient(closest-side, rgba(15, 23, 42, 0.25), transparent);
+  opacity: 0.75;
+  filter: blur(0.5px);
+  pointer-events: none;
 }
 
 .familia-marker__pulse {
   position: absolute;
-  top: 50%;
   left: 50%;
+  bottom: 18px;
   width: 48px;
   height: 48px;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   border-radius: 50%;
   background: rgba(16, 185, 129, 0.18);
   box-shadow: 0 0 0 6px rgba(16, 185, 129, 0.1);
@@ -142,16 +155,15 @@
 
 .familia-marker__icon {
   position: absolute;
-  top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  bottom: 24px;
+  transform: translateX(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
   width: 40px;
   height: 40px;
   border-radius: 50%;
-
   background: linear-gradient(135deg, #2563eb, #1d4ed8);
   color: #fff;
   border: 3px solid rgba(255, 255, 255, 0.95);
@@ -161,5 +173,4 @@
 .familia-marker .fa-solid {
   font-size: 1.1rem;
   filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.35));
-
 }

--- a/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
+++ b/frontend/src/app/modules/georreferenciamento/georreferenciamento.component.ts
@@ -34,15 +34,16 @@ export class GeoReferenciamentoComponent implements OnInit, AfterViewInit, OnDes
   private ajusteMapaTimeout: number | null = null;
   private readonly iconeFamilia = L.divIcon({
     html: `
+      <div class="familia-marker__shadow"></div>
       <div class="familia-marker__pulse"></div>
       <div class="familia-marker__icon">
         <i class="fa-solid fa-house-chimney-window" aria-hidden="true"></i>
       </div>
     `,
     className: 'familia-marker',
-    iconSize: [48, 48],
-    iconAnchor: [24, 24],
-    popupAnchor: [0, -32]
+    iconSize: [48, 64],
+    iconAnchor: [24, 60],
+    popupAnchor: [0, -56]
   });
 
   constructor(


### PR DESCRIPTION
## Summary
- atualiza o ícone HTML dos marcadores para ancorar a base no ponto geográfico das famílias e ajustar o popup
- refina os estilos do marcador adicionando sombra inferior e reposicionando pulsação para acompanhar o novo alinhamento

## Testing
- npm test -- --watch=false
- npm test *(falha: diretório backend-java não possui package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e1edb949508328a8542991c9968ac9