### PR TITLE
Implementa fluxo de parceiros no cadastro familiar

### DIFF
--- a/backend-java/src/main/java/com/gestorpolitico/controller/FamiliaController.java
+++ b/backend-java/src/main/java/com/gestorpolitico/controller/FamiliaController.java
@@ -4,6 +4,7 @@ import com.gestorpolitico.dto.FamiliaFiltroRequestDTO;
 import com.gestorpolitico.dto.FamiliaListaResponseDTO;
 import com.gestorpolitico.dto.FamiliaRequestDTO;
 import com.gestorpolitico.dto.FamiliaResponseDTO;
+import com.gestorpolitico.dto.MembroFamiliaResponseDTO;
 import com.gestorpolitico.service.FamiliaService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -52,6 +53,15 @@ public class FamiliaController {
     Pageable pageable = PageRequest.of(paginaAjustada, tamanhoAjustado, Sort.by(Sort.Direction.DESC, "criadoEm"));
     FamiliaListaResponseDTO familias = familiaService.buscarFamilias(filtro, pageable);
     return ResponseEntity.ok(familias);
+  }
+
+  @PostMapping("/{familiaId}/membros/{membroId}/parceiro")
+  public ResponseEntity<MembroFamiliaResponseDTO> tornarMembroParceiro(
+    @PathVariable Long familiaId,
+    @PathVariable Long membroId
+  ) {
+    MembroFamiliaResponseDTO membro = familiaService.tornarParceiro(familiaId, membroId);
+    return ResponseEntity.ok(membro);
   }
 
   @PutMapping("/{id}")

--- a/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaRequestDTO.java
@@ -29,6 +29,8 @@ public class FamiliaRequestDTO {
   @Valid
   private List<MembroFamiliaRequestDTO> membros;
 
+  private String parceiroToken;
+
   public FamiliaRequestDTO() {
   }
 
@@ -78,5 +80,13 @@ public class FamiliaRequestDTO {
 
   public void setMembros(List<MembroFamiliaRequestDTO> membros) {
     this.membros = membros;
+  }
+
+  public String getParceiroToken() {
+    return parceiroToken;
+  }
+
+  public void setParceiroToken(String parceiroToken) {
+    this.parceiroToken = parceiroToken;
   }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/FamiliaResponseDTO.java
@@ -11,6 +11,7 @@ public class FamiliaResponseDTO {
   private OffsetDateTime criadoEm;
   private EnderecoResponseDTO enderecoDetalhado;
   private List<MembroFamiliaResponseDTO> membros = new ArrayList<>();
+  private ParceiroResumoDTO parceiroCadastro;
 
   public FamiliaResponseDTO() {
   }
@@ -21,7 +22,8 @@ public class FamiliaResponseDTO {
     String bairro,
     OffsetDateTime criadoEm,
     EnderecoResponseDTO enderecoDetalhado,
-    List<MembroFamiliaResponseDTO> membros
+    List<MembroFamiliaResponseDTO> membros,
+    ParceiroResumoDTO parceiroCadastro
   ) {
     this.id = id;
     this.endereco = endereco;
@@ -31,6 +33,7 @@ public class FamiliaResponseDTO {
     if (membros != null) {
       this.membros = membros;
     }
+    this.parceiroCadastro = parceiroCadastro;
   }
 
   public Long getId() {
@@ -79,5 +82,13 @@ public class FamiliaResponseDTO {
 
   public void setMembros(List<MembroFamiliaResponseDTO> membros) {
     this.membros = membros;
+  }
+
+  public ParceiroResumoDTO getParceiroCadastro() {
+    return parceiroCadastro;
+  }
+
+  public void setParceiroCadastro(ParceiroResumoDTO parceiroCadastro) {
+    this.parceiroCadastro = parceiroCadastro;
   }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaRequestDTO.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public class MembroFamiliaRequestDTO {
+  private Long id;
   @NotBlank(message = "O nome completo é obrigatório.")
   @Size(max = 255, message = "O nome completo deve ter no máximo 255 caracteres.")
   private String nomeCompleto;
@@ -31,6 +32,14 @@ public class MembroFamiliaRequestDTO {
   private String telefone;
 
   public MembroFamiliaRequestDTO() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
   }
 
   public String getNomeCompleto() {

--- a/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/MembroFamiliaResponseDTO.java
@@ -14,6 +14,9 @@ public class MembroFamiliaResponseDTO {
   private String probabilidadeVoto;
   private String telefone;
   private OffsetDateTime criadoEm;
+  private boolean parceiro;
+  private Long parceiroId;
+  private String parceiroToken;
 
   public MembroFamiliaResponseDTO() {
   }
@@ -27,7 +30,10 @@ public class MembroFamiliaResponseDTO {
     boolean responsavelPrincipal,
     String probabilidadeVoto,
     String telefone,
-    OffsetDateTime criadoEm
+    OffsetDateTime criadoEm,
+    boolean parceiro,
+    Long parceiroId,
+    String parceiroToken
   ) {
     this.id = id;
     this.nomeCompleto = nomeCompleto;
@@ -38,6 +44,9 @@ public class MembroFamiliaResponseDTO {
     this.probabilidadeVoto = probabilidadeVoto;
     this.telefone = telefone;
     this.criadoEm = criadoEm;
+    this.parceiro = parceiro;
+    this.parceiroId = parceiroId;
+    this.parceiroToken = parceiroToken;
   }
 
   public Long getId() {
@@ -110,5 +119,29 @@ public class MembroFamiliaResponseDTO {
 
   public void setCriadoEm(OffsetDateTime criadoEm) {
     this.criadoEm = criadoEm;
+  }
+
+  public boolean isParceiro() {
+    return parceiro;
+  }
+
+  public void setParceiro(boolean parceiro) {
+    this.parceiro = parceiro;
+  }
+
+  public Long getParceiroId() {
+    return parceiroId;
+  }
+
+  public void setParceiroId(Long parceiroId) {
+    this.parceiroId = parceiroId;
+  }
+
+  public String getParceiroToken() {
+    return parceiroToken;
+  }
+
+  public void setParceiroToken(String parceiroToken) {
+    this.parceiroToken = parceiroToken;
   }
 }

--- a/backend-java/src/main/java/com/gestorpolitico/dto/ParceiroResumoDTO.java
+++ b/backend-java/src/main/java/com/gestorpolitico/dto/ParceiroResumoDTO.java
@@ -1,0 +1,39 @@
+package com.gestorpolitico.dto;
+
+public class ParceiroResumoDTO {
+  private Long id;
+  private String nome;
+  private String token;
+
+  public ParceiroResumoDTO() {}
+
+  public ParceiroResumoDTO(Long id, String nome, String token) {
+    this.id = id;
+    this.nome = nome;
+    this.token = token;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getNome() {
+    return nome;
+  }
+
+  public void setNome(String nome) {
+    this.nome = nome;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+}

--- a/backend-java/src/main/java/com/gestorpolitico/entity/Familia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/Familia.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
@@ -44,6 +45,10 @@ public class Familia {
 
   @OneToMany(mappedBy = "familia", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   private List<MembroFamilia> membros = new ArrayList<>();
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parceiro_cadastro_id")
+  private Parceiro parceiroCadastro;
 
   public Long getId() {
     return id;
@@ -96,6 +101,14 @@ public class Familia {
   public void adicionarMembro(MembroFamilia membro) {
     membro.setFamilia(this);
     this.membros.add(membro);
+  }
+
+  public Parceiro getParceiroCadastro() {
+    return parceiroCadastro;
+  }
+
+  public void setParceiroCadastro(Parceiro parceiroCadastro) {
+    this.parceiroCadastro = parceiroCadastro;
   }
 
   @PrePersist

--- a/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/MembroFamilia.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
@@ -59,6 +60,9 @@ public class MembroFamilia {
 
   @Column(name = "criado_em", nullable = false)
   private OffsetDateTime criadoEm = OffsetDateTime.now();
+
+  @OneToOne(mappedBy = "membro", fetch = FetchType.LAZY)
+  private Parceiro parceiro;
 
   public Long getId() {
     return id;
@@ -138,6 +142,14 @@ public class MembroFamilia {
 
   public void setCriadoEm(OffsetDateTime criadoEm) {
     this.criadoEm = criadoEm;
+  }
+
+  public Parceiro getParceiro() {
+    return parceiro;
+  }
+
+  public void setParceiro(Parceiro parceiro) {
+    this.parceiro = parceiro;
   }
 
   @PrePersist

--- a/backend-java/src/main/java/com/gestorpolitico/entity/Parceiro.java
+++ b/backend-java/src/main/java/com/gestorpolitico/entity/Parceiro.java
@@ -1,0 +1,70 @@
+package com.gestorpolitico.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "parceiro")
+public class Parceiro {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "membro_id", nullable = false, unique = true)
+  private MembroFamilia membro;
+
+  @Column(name = "token", nullable = false, unique = true, length = 64)
+  private String token;
+
+  @Column(name = "criado_em", nullable = false)
+  private OffsetDateTime criadoEm = OffsetDateTime.now();
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public MembroFamilia getMembro() {
+    return membro;
+  }
+
+  public void setMembro(MembroFamilia membro) {
+    this.membro = membro;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+
+  public OffsetDateTime getCriadoEm() {
+    return criadoEm;
+  }
+
+  public void setCriadoEm(OffsetDateTime criadoEm) {
+    this.criadoEm = criadoEm;
+  }
+
+  @PrePersist
+  public void prePersist() {
+    if (criadoEm == null) {
+      criadoEm = OffsetDateTime.now();
+    }
+  }
+}

--- a/backend-java/src/main/java/com/gestorpolitico/repository/ParceiroRepository.java
+++ b/backend-java/src/main/java/com/gestorpolitico/repository/ParceiroRepository.java
@@ -1,0 +1,13 @@
+package com.gestorpolitico.repository;
+
+import com.gestorpolitico.entity.Parceiro;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParceiroRepository extends JpaRepository<Parceiro, Long> {
+  Optional<Parceiro> findByToken(String token);
+
+  Optional<Parceiro> findByMembroId(Long membroId);
+
+  boolean existsByToken(String token);
+}

--- a/backend-java/src/main/resources/db/ddl.sql
+++ b/backend-java/src/main/resources/db/ddl.sql
@@ -61,3 +61,16 @@ CREATE TABLE IF NOT EXISTS membro_familia (
   familia_id BIGINT NOT NULL REFERENCES familia (id) ON DELETE CASCADE,
   criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS parceiro (
+  id BIGSERIAL PRIMARY KEY,
+  membro_id BIGINT NOT NULL UNIQUE REFERENCES membro_familia (id) ON DELETE RESTRICT,
+  token VARCHAR(64) NOT NULL UNIQUE,
+  criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+ALTER TABLE familia
+  ADD COLUMN IF NOT EXISTS parceiro_cadastro_id BIGINT REFERENCES parceiro (id);
+
+CREATE INDEX IF NOT EXISTS idx_familia_parceiro_cadastro
+  ON familia (parceiro_cadastro_id);

--- a/backend-java/src/main/resources/db/migration/V5__criar_parceiros.sql
+++ b/backend-java/src/main/resources/db/migration/V5__criar_parceiros.sql
@@ -1,0 +1,17 @@
+CREATE TABLE parceiro (
+  id BIGSERIAL PRIMARY KEY,
+  membro_id BIGINT NOT NULL UNIQUE REFERENCES membro_familia (id) ON DELETE RESTRICT,
+  token VARCHAR(64) NOT NULL UNIQUE,
+  criado_em TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+ALTER TABLE familia
+  ADD COLUMN parceiro_cadastro_id BIGINT;
+
+ALTER TABLE familia
+  ADD CONSTRAINT fk_familia_parceiro
+  FOREIGN KEY (parceiro_cadastro_id)
+  REFERENCES parceiro (id);
+
+CREATE INDEX idx_familia_parceiro_cadastro
+  ON familia (parceiro_cadastro_id);

--- a/frontend/src/app/modules/familias/familias.service.ts
+++ b/frontend/src/app/modules/familias/familias.service.ts
@@ -5,6 +5,7 @@ import { buildApiUrl } from '../shared/api-url.util';
 import { GrauParentesco } from './parentesco.enum';
 
 export interface FamiliaMembroPayload {
+  id?: number | null;
   nomeCompleto: string;
   dataNascimento: string | null;
   profissao: string | null;
@@ -21,6 +22,7 @@ export interface FamiliaPayload {
   cidadeId: number;
   novaRegiao: string | null;
   membros: FamiliaMembroPayload[];
+  parceiroToken?: string | null;
 }
 
 export interface EnderecoFamiliaResponse {
@@ -46,6 +48,9 @@ export interface FamiliaMembroResponse {
   probabilidadeVoto: string;
   telefone: string | null;
   criadoEm: string;
+  parceiro: boolean;
+  parceiroId: number | null;
+  parceiroToken: string | null;
 }
 
 export interface FamiliaResponse {
@@ -55,6 +60,11 @@ export interface FamiliaResponse {
   criadoEm: string;
   enderecoDetalhado: EnderecoFamiliaResponse;
   membros: FamiliaMembroResponse[];
+  parceiroCadastro?: {
+    id: number;
+    nome: string | null;
+    token: string;
+  } | null;
 }
 
 export interface FamiliaFiltro {
@@ -125,5 +135,12 @@ export class FamiliasService {
 
   atualizarFamilia(id: number, payload: FamiliaPayload): Observable<FamiliaResponse> {
     return this.http.put<FamiliaResponse>(`${this.apiUrl}/${id}`, payload);
+  }
+
+  tornarMembroParceiro(familiaId: number, membroId: number): Observable<FamiliaMembroResponse> {
+    return this.http.post<FamiliaMembroResponse>(
+      `${this.apiUrl}/${familiaId}/membros/${membroId}/parceiro`,
+      {}
+    );
   }
 }

--- a/frontend/src/app/modules/familias/mobile/familias-mobile.component.html
+++ b/frontend/src/app/modules/familias/mobile/familias-mobile.component.html
@@ -261,22 +261,63 @@
         </div>
 
         <div class="space-y-2">
-          <h4 class="text-xs font-semibold text-gray-500 uppercase">Membros secundários</h4>
-          <ng-container *ngIf="membrosSecundarios(familia) as secundarios">
-            <ul class="space-y-2">
-              <li
-                *ngFor="let membro of secundarios; let ultimo = last"
-                class="text-sm text-gray-700 flex items-center justify-between"
-              >
-                <span>{{ membro.nomeCompleto }}</span>
-                <span class="text-xs text-gray-500">{{ membro.relacaoFamiliar || 'Parente' }}</span>
-                <div *ngIf="!ultimo" class="hidden"></div>
-              </li>
-              <li *ngIf="secundarios.length === 0" class="text-sm text-gray-500">
-                Nenhum membro adicional cadastrado.
-              </li>
-            </ul>
-          </ng-container>
+          <h4 class="text-xs font-semibold text-gray-500 uppercase">Membros da família</h4>
+          <ul *ngIf="familia.membros.length > 0; else nenhumMembro" class="space-y-2">
+            <li
+              *ngFor="let membro of familia.membros"
+              class="flex items-center justify-between gap-3 text-sm text-gray-700"
+            >
+              <div class="flex flex-col">
+                <span class="font-semibold text-gray-800">{{ membro.nomeCompleto }}</span>
+                <span class="text-xs text-gray-500">{{ descricaoParentesco(membro) }}</span>
+              </div>
+              <ng-container *ngIf="membro.parceiro && membro.parceiroToken; else acaoParceiro">
+                <a
+                  class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-semibold text-emerald-600 bg-emerald-50 rounded-full hover:bg-emerald-100"
+                  [routerLink]="['/familias/nova']"
+                  [queryParams]="{ parceiroToken: membro.parceiroToken }"
+                  (click)="$event.stopPropagation()"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M10 14L21 3m-4 0h4v4"
+                    ></path>
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M14 10l-1.5 1.5M8 6H4a1 1 0 00-1 1v13a1 1 0 001 1h13a1 1 0 001-1v-4"
+                    ></path>
+                  </svg>
+                  Painel
+                </a>
+              </ng-container>
+              <ng-template #acaoParceiro>
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-semibold text-blue-600 border border-blue-200 rounded-full hover:bg-blue-50 disabled:opacity-60"
+                  (click)="tornarParceiro($event, familia, membro)"
+                  [disabled]="emProcessoParceiro(membro)"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M13.828 10.172a4 4 0 015.656 5.656l-2.828 2.828a4 4 0 01-5.656 0M10.172 13.828a4 4 0 01-5.656-5.656l2.828-2.828a4 4 0 015.656 0"
+                    ></path>
+                  </svg>
+                  {{ emProcessoParceiro(membro) ? 'Gerando...' : 'Gerar link' }}
+                </button>
+              </ng-template>
+            </li>
+          </ul>
+          <ng-template #nenhumMembro>
+            <p class="text-sm text-gray-500">Nenhum membro cadastrado.</p>
+          </ng-template>
         </div>
       </article>
     </section>

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -30,7 +30,7 @@
       </div>
       <div class="flex items-center space-x-3">
         <button
-          *ngIf="modoEdicao && familiaIdEdicao"
+          *ngIf="modoEdicao && familiaIdEdicao && !modoParceiro"
           type="button"
           (click)="abrirDemandasFamilia()"
           class="px-4 py-2 bg-blue-100 text-blue-700 rounded-xl font-medium hover:bg-blue-200 transition-colors flex items-center gap-2"
@@ -54,6 +54,97 @@
 
 <div class="bg-gradient-to-br from-gray-50 via-white to-blue-50 min-h-screen">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div *ngIf="modoParceiro" class="bg-blue-50 border border-blue-200 rounded-3xl p-6 mb-6 space-y-5">
+      <div class="flex items-start gap-3">
+        <div class="w-10 h-10 bg-white rounded-full flex items-center justify-center text-blue-600 font-semibold">
+          <span>PR</span>
+        </div>
+        <div>
+          <h2 class="text-lg font-semibold text-blue-900">Painel do parceiro</h2>
+          <p class="text-sm text-blue-700">
+            Utilize seu link exclusivo para cadastrar novas famílias e consultar cadastros existentes antes de adicionar um novo registro.
+          </p>
+        </div>
+      </div>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="bg-white border border-blue-100 rounded-2xl p-4 shadow-sm">
+          <div class="text-xs font-semibold text-blue-500 uppercase tracking-wide">Seu link</div>
+          <div class="mt-2 text-sm text-blue-900 break-all">
+            {{ linkParceiroCompleto || ('/familias/nova?parceiroToken=' + parceiroTokenContext) }}
+          </div>
+          <p class="mt-2 text-xs text-blue-600">
+            Compartilhe este endereço para que o parceiro acesse o cadastro simplificado de famílias.
+          </p>
+        </div>
+        <div class="bg-white border border-blue-100 rounded-2xl p-4 shadow-sm">
+          <div class="text-xs font-semibold text-blue-500 uppercase tracking-wide">Dica</div>
+          <p class="mt-2 text-sm text-blue-900">
+            Cadastros feitos através deste link ficam automaticamente vinculados ao parceiro escolhido.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div *ngIf="modoParceiro" class="bg-white rounded-3xl shadow-card border border-blue-100 p-6 mb-6 space-y-4">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-gray-900">Pesquisar famílias existentes</h2>
+          <p class="text-sm text-gray-500">
+            Consulte se a família já está cadastrada antes de criar um novo registro.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="px-4 py-2 text-sm font-semibold text-blue-600 bg-blue-50 rounded-xl border border-blue-200 hover:bg-blue-100 transition"
+          (click)="limparBuscaParceiro()"
+        >
+          Limpar busca
+        </button>
+      </div>
+      <div class="flex flex-col sm:flex-row gap-3">
+        <input
+          type="text"
+          class="w-full px-4 py-3 border-2 border-blue-100 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition"
+          placeholder="Nome do responsável, endereço ou palavra-chave"
+          [(ngModel)]="termoBuscaParceiro"
+        />
+        <button
+          type="button"
+          class="px-6 py-3 text-sm font-semibold text-white gradient-blue rounded-xl shadow-md disabled:opacity-60"
+          (click)="buscarFamiliasParceiro()"
+          [disabled]="buscandoFamiliasParceiro"
+        >
+          {{ buscandoFamiliasParceiro ? 'Buscando...' : 'Buscar' }}
+        </button>
+      </div>
+      <p *ngIf="erroBuscaParceiro" class="text-sm text-red-500">{{ erroBuscaParceiro }}</p>
+      <div *ngIf="familiasEncontradas.length > 0" class="grid gap-3">
+        <div
+          *ngFor="let familia of familiasEncontradas"
+          class="border border-gray-200 rounded-2xl p-4 bg-gray-50 text-sm text-gray-700"
+        >
+          <div class="font-semibold text-gray-900">
+            {{ obterResponsavelServidor(familia) || 'Responsável não informado' }}
+          </div>
+          <div>{{ familia.endereco }}</div>
+          <div class="text-xs text-gray-500">
+            Cadastrada em {{ familia.criadoEm | date: 'shortDate' }}
+          </div>
+        </div>
+      </div>
+      <p
+        *ngIf="
+          !buscandoFamiliasParceiro &&
+          familiasEncontradas.length === 0 &&
+          !erroBuscaParceiro &&
+          termoBuscaParceiro.trim().length > 0
+        "
+        class="text-sm text-gray-500"
+      >
+        Nenhuma família encontrada com o termo informado.
+      </p>
+    </div>
+
     <div class="bg-white rounded-3xl shadow-card border border-gray-100 p-8 mb-6">
       <div class="flex items-center space-x-3 mb-6">
         <div class="w-8 h-8 gradient-blue rounded-lg flex items-center justify-center">


### PR DESCRIPTION
## Resumo
- cria entidade de parceiro e registra famílias com vínculo ao parceiro no backend
- adiciona endpoint para transformar membros em parceiros e expor link dedicado
- ajusta tela mobile de famílias para gerar link de parceiro e mostrar acesso rápido
- habilita modo parceiro no cadastro móvel com busca de famílias e envio do token

## Testes
- `npm test -- --watch=false`
- `npm test` *(falha: backend-java não possui package.json para executar npm test)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ed058c048328b168a2f992b4e622