### PR TITLE
Ajusta layout do cadastro de parceiro no mobile

### DIFF
--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.css
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.css
@@ -51,3 +51,11 @@
     opacity: 1;
   }
 }
+
+select,
+input[type='date'] {
+  min-height: 3.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  line-height: 1.5;
+}

--- a/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
+++ b/frontend/src/app/modules/familias/nova-familia/nova-familia.component.html
@@ -1,4 +1,4 @@
-<div class="bg-white border-b border-gray-200 shadow-sm sticky top-0 z-10">
+<div *ngIf="!modoParceiro" class="bg-white border-b border-gray-200 shadow-sm sticky top-0 z-10">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:py-0">
       <div class="flex flex-wrap items-center gap-3 sm:flex-nowrap sm:gap-4">
@@ -191,6 +191,7 @@
                 placeholder="00000-000"
                 maxlength="9"
                 autocomplete="postal-code"
+                inputmode="numeric"
               />
               <div class="flex items-center space-x-2">
                 <button
@@ -224,6 +225,7 @@
             class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-4 focus:ring-blue-100 focus:border-blue-500 transition-all duration-200"
             [(ngModel)]="enderecoFamilia.numero"
             name="numeroFamilia"
+            inputmode="numeric"
           />
         </div>
 
@@ -434,6 +436,7 @@
                   (ngModelChange)="atualizarTelefoneMembro(i, $event)"
                   name="telefone_{{ i }}"
                   placeholder="(11) 99999-9999"
+                  inputmode="numeric"
                 />
                 <button
                   type="button"


### PR DESCRIPTION
## Resumo
- remove a barra superior com a ação de cancelar quando o cadastro é feito via parceiro
- padroniza a altura dos campos de seleção e de data com os demais campos de texto
- ativa o teclado numérico em campos de CEP, número e telefone em dispositivos móveis

## Testes
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68f6dab0009c8328b3d14c2b35cfd2ec